### PR TITLE
Playground: lean lens (canonical bytes, both engines)

### DIFF
--- a/book/src/playground.md
+++ b/book/src/playground.md
@@ -25,6 +25,8 @@ Drop a PDF on it and every page appears with:
   - **x-ray** — the page dimmed with wireframe boxes over it
   - **text** — the extracted content, element by element
   - **json** — the page's JSON, syntax-highlighted, with a copy button
+  - **lean** — the whole document in the token-lean format (canonical bytes
+    from the same renderer as `--format lean`), with a copy button
 - **Cross-panel sync** — click any box and the opposite panel jumps to and
   flashes that exact element's JSON; click a JSON element and its box flashes
   on the page.

--- a/crates/docray-server/assets/playground.html
+++ b/crates/docray-server/assets/playground.html
@@ -316,7 +316,7 @@ const $ = (s, r) => (r || document).querySelector(s);
 const TYPES = ["text", "image", "path", "annotation"];
 const VIEWS = [
   ["source", "source"], ["boxes", "boxes"], ["xray", "x-ray"],
-  ["text", "text"], ["json", "json"],
+  ["text", "text"], ["json", "json"], ["lean", "lean"],
 ];
 
 // `gen` is a generation token: every upload bumps it; async work still in
@@ -404,7 +404,7 @@ function retireWorker(inst) {
   if (workerInstance === inst) workerInstance = null;
 }
 
-function browserExtract(bytes, gran, signal) {
+function browserExtract(bytes, gran, signal, cmd = "extract") {
   if (bytes.byteLength > BROWSER_INPUT_CAP) {
     return Promise.reject(new Error("too_large · in-browser engine caps input at " + fmtBytes(BROWSER_INPUT_CAP)));
   }
@@ -444,7 +444,7 @@ function browserExtract(bytes, gran, signal) {
     inst.busy = req;
     try {
       inst.w.postMessage(
-        { id, cmd: "extract", bytes, granularity: gran === "char" ? "" : gran, cap: BROWSER_INPUT_CAP },
+        { id, cmd, bytes, granularity: gran === "char" ? "" : gran, cap: BROWSER_INPUT_CAP },
         [bytes],
       );
     } catch (e) {
@@ -452,6 +452,28 @@ function browserExtract(bytes, gran, signal) {
       req.reject(e);
     }
   });
+}
+
+/* Canonical lean bytes for the whole document: same Rust renderer as the
+   CLI/API — the lens never re-implements the format in JS. Lean requires
+   element|word; when the UI is on char granularity the lens shows element
+   (the same implication the CLI/HTTP surfaces make). */
+async function fetchLean() {
+  const gran = $("#gran").value === "word" ? "word" : "element";
+  if (state.leanCache && state.leanCache[gran]) return state.leanCache[gran];
+  let text;
+  if (engines.current === "browser") {
+    const bytes = await state.file.arrayBuffer();
+    ({ json: text } = await browserExtract(bytes, gran, null, "extract_lean"));
+  } else {
+    const fd = new FormData();
+    fd.append("file", state.file, state.file.name);
+    const res = await fetch(`/v1/extract?format=lean&granularity=${gran}`, { method: "POST", body: fd });
+    if (!res.ok) throw new Error("lean fetch failed: http " + res.status);
+    text = await res.text();
+  }
+  state.leanCache[gran] = text;
+  return text;
 }
 
 async function serverExtract(file, gran, signal) {
@@ -564,6 +586,7 @@ async function load(file, keepPageIdx) {
   state.file = file;
   state.fileName = file.name;
   state.extraction = extraction;
+  state.leanCache = {}; // canonical lean bytes, keyed by granularity
   state.pdf = pdf;
   state.pageIdx = Math.min(keepPageIdx || 0, extraction.pages.length - 1);
   state.zoom = 1;
@@ -770,6 +793,38 @@ async function renderPanel(i, gen) {
         }
       };
     });
+    return;
+  }
+
+  if (mode === "lean") {
+    body.className = "panel-body";
+    body.innerHTML = '<p style="color:var(--fg-dim)">rendering lean …</p>';
+    const req = (panelReq[i] = (panelReq[i] || 0) + 1);
+    try {
+      const text = await fetchLean();
+      if (req !== panelReq[i] || gen !== state.gen || mode !== state.panelModes[i]) return;
+      body.innerHTML = "";
+      const actions = document.createElement("div");
+      actions.className = "jv-actions";
+      const copy = document.createElement("button");
+      copy.className = "btn";
+      copy.textContent = "copy";
+      copy.onclick = () => navigator.clipboard.writeText(text);
+      actions.appendChild(copy);
+      const pre = document.createElement("pre");
+      pre.className = "jv";
+      const gran = $("#gran").value === "word" ? "word" : "element";
+      pre.textContent = ($("#gran").value === "char"
+        ? "(lean is a compact reading format — showing element granularity)\n" : "") + text;
+      body.append(actions, pre);
+    } catch (e) {
+      if (req !== panelReq[i] || gen !== state.gen) return;
+      body.innerHTML = "";
+      const p = document.createElement("p");
+      p.style.color = "var(--fg-dim)";
+      p.textContent = "lean render failed · " + e.message;
+      body.appendChild(p);
+    }
     return;
   }
 

--- a/crates/docray-wasm/src/lib.rs
+++ b/crates/docray-wasm/src/lib.rs
@@ -10,7 +10,7 @@
 //! docray-server's native subprocess isolation.
 
 use docray_core::{ExtractError, Extractor};
-use docray_model::Granularity;
+use docray_model::{GranularExtraction, Granularity};
 use docray_pdf::PdfExtractor;
 use wasm_bindgen::prelude::*;
 
@@ -26,6 +26,53 @@ use wasm_bindgen::prelude::*;
 pub fn extract(bytes: &[u8], granularity: &str, max_input_bytes: usize) -> Result<String, JsValue> {
     install_panic_hook();
     extract_inner(bytes, granularity, max_input_bytes).map_err(WasmError::into_js)
+}
+
+/// Extracts a PDF and returns the token-lean line format (see the docs'
+/// Output formats page). `granularity` accepts "element", "word", or the
+/// empty string (implies element, matching the CLI/HTTP surfaces). "char" is
+/// rejected with the stable `bad_format` error code, like everywhere else.
+#[wasm_bindgen]
+pub fn extract_lean(
+    bytes: &[u8],
+    granularity: &str,
+    max_input_bytes: usize,
+) -> Result<String, JsValue> {
+    install_panic_hook();
+    extract_lean_inner(bytes, granularity, max_input_bytes).map_err(WasmError::into_js)
+}
+
+fn extract_lean_inner(
+    bytes: &[u8],
+    granularity: &str,
+    max_input_bytes: usize,
+) -> Result<String, WasmError> {
+    if max_input_bytes != 0 && bytes.len() > max_input_bytes {
+        return Err(WasmError::new(
+            "too_large",
+            format!(
+                "input is {} bytes, limit is {max_input_bytes} bytes",
+                bytes.len()
+            ),
+        ));
+    }
+    let granularity = match granularity {
+        "" | "element" => Granularity::Element,
+        "word" => Granularity::Word,
+        other => {
+            return Err(WasmError::new(
+                "bad_format",
+                format!("lean format requires element or word granularity, got {other:?}"),
+            ))
+        }
+    };
+    let extraction = PdfExtractor
+        .extract(bytes, None)
+        .map_err(WasmError::from_extract)?;
+    match extraction.with_granularity(granularity) {
+        GranularExtraction::Compact(compact) => Ok(compact.to_lean()),
+        GranularExtraction::Char(_) => unreachable!("char is rejected above"),
+    }
 }
 
 fn extract_inner(

--- a/scripts/wasm-parity.cjs
+++ b/scripts/wasm-parity.cjs
@@ -21,6 +21,22 @@ function exact(failures, label, a, b) {
   }
 }
 
+
+/* Numeric-aware lean line comparison: numbers must agree within the same 2pt
+   tolerance the JSON comparator uses (native and wasm pdfium builds have
+   sub-point glyph-metric variance); everything non-numeric must match
+   exactly, so any real format/content divergence still fails. */
+function leanLineClose(a, b) {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  const num = /-?\d+(?:\.\d+)?/g;
+  if (a.replace(num, "#") !== b.replace(num, "#")) return false;
+  const an = a.match(num) || [];
+  const bn = b.match(num) || [];
+  if (an.length !== bn.length) return false;
+  return an.every((x, i) => Math.abs(Number(x) - Number(bn[i])) <= 2);
+}
+
 function compare(native, wasm) {
   const failures = [];
   let geometryComparisons = 0;
@@ -173,6 +189,30 @@ async function main() {
     const native = JSON.parse(nativeRun.stdout);
     const wasm = JSON.parse(docray.extract(fs.readFileSync(fixturePath), "", 0));
     results.push({ fixture, ...compare(native, wasm) });
+
+    // Lean output must match wasm-vs-native: same Rust renderer over the
+    // same extraction. Structure/content compare exactly; numbers within
+    // the JSON comparator's 2pt tolerance (pdfium builds differ sub-point).
+    const leanNative = spawnSync(nativeCli, ["extract", fixturePath, "--format", "lean"], {
+      cwd: root,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (leanNative.status !== 0) {
+      throw new Error(`native lean failed for ${fixture}: ${leanNative.stderr.trim()}`);
+    }
+    const leanWasm = docray.extract_lean(fs.readFileSync(fixturePath), "element", 0);
+    const leanLines = { native: leanNative.stdout.split("\n").length, wasm: leanWasm.split("\n").length };
+    const nNorm = leanNative.stdout.split("\n");
+    const wNorm = leanWasm.split("\n");
+    let firstDiff = -1;
+    for (let i = 0; i < Math.max(nNorm.length, wNorm.length); i++) {
+      if (!leanLineClose(nNorm[i], wNorm[i])) { firstDiff = i; break; }
+    }
+    const leanOk = firstDiff === -1;
+    results.push({ fixture: fixture + " (lean)", ok: leanOk, failures: leanOk ? [] : [
+      `lean differs at line ${firstDiff}: native=${JSON.stringify(nNorm[firstDiff])} wasm=${JSON.stringify(wNorm[firstDiff])}`,
+    ], failure_count: leanOk ? 0 : 1 });
   }
 
   const ok = results.every((result) => result.ok);

--- a/web/worker.js
+++ b/web/worker.js
@@ -62,11 +62,13 @@ const OUTPUT_CAP_UNITS = 128 * 1024 * 1024;
 
 self.onmessage = async ev => {
   const { id, cmd, bytes, granularity, cap } = ev.data;
-  if (cmd !== "extract") return;
+  if (cmd !== "extract" && cmd !== "extract_lean") return;
   try {
     const docray = await initOnce();
     const t0 = performance.now();
-    const json = docray.extract(new Uint8Array(bytes), granularity || "", cap || 0);
+    const json = cmd === "extract_lean"
+      ? docray.extract_lean(new Uint8Array(bytes), granularity || "", cap || 0)
+      : docray.extract(new Uint8Array(bytes), granularity || "", cap || 0);
     if (json.length > OUTPUT_CAP_UNITS) {
       postMessage({ id, ok: false, error: { code: "output_too_large",
         message: "extraction produced " + json.length + " code units (cap " + OUTPUT_CAP_UNITS + ")" } });


### PR DESCRIPTION
Adds **lean** as a sixth panel lens in the playground/demo, showing the whole document in the token-lean format with a copy button. Canonical-bytes discipline: server mode fetches `?format=lean`, browser mode calls a new `extract_lean` wasm export through the reviewed worker RPC — no JS re-implementation to drift. Char granularity implies element (same rule as CLI/HTTP). The wasm parity CI gate now also compares lean output native-vs-wasm (2pt numeric tolerance, structure exact). Verified via headless-browser e2e in both engines including live granularity switching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)