### PR TITLE
Enforce WASM output cap during serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "docray-core",
  "docray-model",
  "docray-pdf",
+ "serde",
  "serde_json",
  "wasm-bindgen",
 ]

--- a/crates/docray-model/src/lib.rs
+++ b/crates/docray-model/src/lib.rs
@@ -354,33 +354,39 @@ impl CompactExtraction {
     /// Renders the deterministic, line-oriented reading format. Compact
     /// extractions can only have element or word granularity.
     pub fn to_lean(&self) -> String {
+        let mut output = String::new();
+        self.write_lean(&mut output)
+            .expect("writing to a String cannot fail");
+        output
+    }
+
+    /// Streams the lean rendering into any [`fmt::Write`], so callers can
+    /// bound output growth DURING generation (e.g. a size-capped writer that
+    /// errors once a byte budget is exceeded) instead of materializing the
+    /// whole document first.
+    pub fn write_lean<W: fmt::Write>(&self, output: &mut W) -> fmt::Result {
         debug_assert!(matches!(
             self.granularity,
             Granularity::Element | Granularity::Word
         ));
-
-        let mut output = String::new();
         write!(
             output,
             "#docray {} v{} pages={}",
             self.granularity, self.schema_version, self.document.page_count
-        )
-        .expect("writing to a String cannot fail");
+        )?;
         if !self.warnings.is_empty() {
-            write!(output, " warnings={}", self.warnings.len())
-                .expect("writing to a String cannot fail");
+            write!(output, " warnings={}", self.warnings.len())?;
         }
-        output.push('\n');
-        output.push_str(match self.granularity {
+        output.write_char('\n')?;
+        output.write_str(match self.granularity {
             Granularity::Element => ELEMENT_LEGEND,
             Granularity::Word => WORD_LEGEND,
             Granularity::Char => unreachable!("char does not use compact output"),
-        });
-        output.push('\n');
+        })?;
+        output.write_char('\n')?;
 
         for warning in &self.warnings {
-            writeln!(output, "#warning {}", collapse_warning(warning))
-                .expect("writing to a String cannot fail");
+            writeln!(output, "#warning {}", collapse_warning(warning))?;
         }
 
         for page in &self.pages {
@@ -390,15 +396,14 @@ impl CompactExtraction {
                 page.page_number,
                 lean_number(page.width),
                 lean_number(page.height)
-            )
-            .expect("writing to a String cannot fail");
+            )?;
             if page.rotation != 0 {
-                write!(output, " rot={}", page.rotation).expect("writing to a String cannot fail");
+                write!(output, " rot={}", page.rotation)?;
             }
             if page.scanned {
-                output.push_str(" scanned");
+                output.write_str(" scanned")?;
             }
-            output.push('\n');
+            output.write_char('\n')?;
 
             for element in &page.elements {
                 match element {
@@ -413,12 +418,10 @@ impl CompactExtraction {
                                     output,
                                     "T {bbox} {font} {size} {style} {}",
                                     escape_text(text)
-                                )
-                                .expect("writing to a String cannot fail");
+                                )?;
                             }
                             CompactTextContent::Word { words } => {
-                                writeln!(output, "T {bbox} {font} {size} {style}")
-                                    .expect("writing to a String cannot fail");
+                                writeln!(output, "T {bbox} {font} {size} {style}")?;
                                 for word in words {
                                     writeln!(
                                         output,
@@ -428,19 +431,16 @@ impl CompactExtraction {
                                         lean_number(word.3),
                                         lean_number(word.4),
                                         escape_text(&word.0)
-                                    )
-                                    .expect("writing to a String cannot fail");
+                                    )?;
                                 }
                             }
                         }
                     }
                     CompactElement::Image(image) => {
-                        writeln!(output, "I {}", lean_bbox(&image.bbox))
-                            .expect("writing to a String cannot fail");
+                        writeln!(output, "I {}", lean_bbox(&image.bbox))?;
                     }
                     CompactElement::Path(path) => {
-                        writeln!(output, "P {}", lean_bbox(&path.bbox))
-                            .expect("writing to a String cannot fail");
+                        writeln!(output, "P {}", lean_bbox(&path.bbox))?;
                     }
                     CompactElement::Annotation(annotation) => {
                         // URIs are PDF-controlled: escape like text so a crafted
@@ -456,14 +456,13 @@ impl CompactExtraction {
                                 .as_deref()
                                 .map(escape_text)
                                 .unwrap_or_else(|| "-".to_string())
-                        )
-                        .expect("writing to a String cannot fail");
+                        )?;
                     }
                 }
             }
         }
 
-        output
+        Ok(())
     }
 }
 

--- a/crates/docray-wasm/Cargo.toml
+++ b/crates/docray-wasm/Cargo.toml
@@ -11,5 +11,6 @@ crate-type = ["cdylib", "rlib"]
 docray-core = { path = "../docray-core" }
 docray-model = { path = "../docray-model" }
 docray-pdf = { path = "../docray-pdf" }
+serde.workspace = true
 serde_json.workspace = true
 wasm-bindgen = "0.2"

--- a/crates/docray-wasm/src/lib.rs
+++ b/crates/docray-wasm/src/lib.rs
@@ -23,9 +23,14 @@ use wasm_bindgen::prelude::*;
 /// Failures throw a JSON string with docray's stable error envelope. The caller
 /// must parse the thrown string before inspecting `error.code`.
 #[wasm_bindgen]
-pub fn extract(bytes: &[u8], granularity: &str, max_input_bytes: usize) -> Result<String, JsValue> {
+pub fn extract(
+    bytes: &[u8],
+    granularity: &str,
+    max_input_bytes: usize,
+    max_output_bytes: usize,
+) -> Result<String, JsValue> {
     install_panic_hook();
-    extract_inner(bytes, granularity, max_input_bytes).map_err(WasmError::into_js)
+    extract_inner(bytes, granularity, max_input_bytes, max_output_bytes).map_err(WasmError::into_js)
 }
 
 /// Extracts a PDF and returns the token-lean line format (see the docs'
@@ -37,16 +42,20 @@ pub fn extract_lean(
     bytes: &[u8],
     granularity: &str,
     max_input_bytes: usize,
+    max_output_bytes: usize,
 ) -> Result<String, JsValue> {
     install_panic_hook();
-    extract_lean_inner(bytes, granularity, max_input_bytes).map_err(WasmError::into_js)
+    extract_lean_inner(bytes, granularity, max_input_bytes, max_output_bytes)
+        .map_err(WasmError::into_js)
 }
 
 fn extract_lean_inner(
     bytes: &[u8],
     granularity: &str,
     max_input_bytes: usize,
+    max_output_bytes: usize,
 ) -> Result<String, WasmError> {
+    let cap = output_cap(max_output_bytes);
     if max_input_bytes != 0 && bytes.len() > max_input_bytes {
         return Err(WasmError::new(
             "too_large",
@@ -70,7 +79,16 @@ fn extract_lean_inner(
         .extract(bytes, None)
         .map_err(WasmError::from_extract)?;
     match extraction.with_granularity(granularity) {
-        GranularExtraction::Compact(compact) => Ok(compact.to_lean()),
+        GranularExtraction::Compact(compact) => {
+            let mut w = CappedString {
+                buf: String::new(),
+                remaining: cap,
+            };
+            compact.write_lean(&mut w).map_err(|_| {
+                WasmError::new(OUTPUT_TOO_LARGE, format!("output exceeded {cap} bytes"))
+            })?;
+            Ok(w.buf)
+        }
         GranularExtraction::Char(_) => unreachable!("char is rejected above"),
     }
 }
@@ -79,7 +97,9 @@ fn extract_inner(
     bytes: &[u8],
     granularity: &str,
     max_input_bytes: usize,
+    max_output_bytes: usize,
 ) -> Result<String, WasmError> {
+    let cap = output_cap(max_output_bytes);
     if max_input_bytes != 0 && bytes.len() > max_input_bytes {
         return Err(WasmError::new(
             "too_large",
@@ -95,13 +115,12 @@ fn extract_inner(
         .map_err(WasmError::from_extract)?;
 
     if granularity.is_empty() {
-        serde_json::to_string(&extraction).map_err(WasmError::parse_failure)
+        json_capped(&extraction, cap)
     } else {
         let granularity = granularity
             .parse::<Granularity>()
             .map_err(WasmError::parse_failure)?;
-        serde_json::to_string(&extraction.with_granularity(granularity))
-            .map_err(WasmError::parse_failure)
+        json_capped(&extraction.with_granularity(granularity), cap)
     }
 }
 
@@ -142,6 +161,72 @@ impl WasmError {
     }
 }
 
+/// Byte budget exceeded during output generation.
+const OUTPUT_TOO_LARGE: &str = "output_too_large";
+
+/// `fmt::Write` that errors once a byte budget is exhausted, so lean
+/// rendering aborts instead of materializing an unbounded string.
+struct CappedString {
+    buf: String,
+    remaining: usize,
+}
+
+impl std::fmt::Write for CappedString {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        if s.len() > self.remaining {
+            return Err(std::fmt::Error);
+        }
+        self.remaining -= s.len();
+        self.buf.push_str(s);
+        Ok(())
+    }
+}
+
+/// `io::Write` twin for serde_json, bounding JSON serialization the same way.
+struct CappedVec {
+    buf: Vec<u8>,
+    remaining: usize,
+}
+
+impl std::io::Write for CappedVec {
+    fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+        if data.len() > self.remaining {
+            return Err(std::io::Error::other("output budget exceeded"));
+        }
+        self.remaining -= data.len();
+        self.buf.extend_from_slice(data);
+        Ok(data.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn output_cap(max_output_bytes: usize) -> usize {
+    if max_output_bytes == 0 {
+        usize::MAX
+    } else {
+        max_output_bytes
+    }
+}
+
+fn json_capped<T: serde::Serialize>(value: &T, cap: usize) -> Result<String, WasmError> {
+    let mut w = CappedVec {
+        buf: Vec::new(),
+        remaining: cap,
+    };
+    match serde_json::to_writer(&mut w, value) {
+        Ok(()) => {
+            String::from_utf8(w.buf).map_err(|e| WasmError::new("parse_failure", e.to_string()))
+        }
+        Err(e) if e.is_io() => Err(WasmError::new(
+            OUTPUT_TOO_LARGE,
+            format!("output exceeded {cap} bytes"),
+        )),
+        Err(e) => Err(WasmError::new("parse_failure", e.to_string())),
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 fn install_panic_hook() {
     std::panic::set_hook(Box::new(|_| {
@@ -169,7 +254,7 @@ mod tests {
 
     #[test]
     fn input_cap_precedes_pdfium() {
-        let error = extract_inner(&[0; 3], "", 2).unwrap_err();
+        let error = extract_inner(&[0; 3], "", 2, 0).unwrap_err();
 
         assert_eq!(error.code, "too_large");
         assert_eq!(error.message, "input is 3 bytes, limit is 2 bytes");
@@ -177,8 +262,39 @@ mod tests {
 
     #[test]
     fn zero_input_cap_is_uncapped() {
-        let error = extract_inner(b"not a PDF", "", 0).unwrap_err();
+        let error = extract_inner(b"not a PDF", "", 0, 0).unwrap_err();
 
         assert_ne!(error.code, "too_large");
+    }
+
+    use std::fmt::Write as _;
+    use std::io::Write as _;
+
+    #[test]
+    fn capped_string_errors_at_budget() {
+        let mut w = CappedString {
+            buf: String::new(),
+            remaining: 5,
+        };
+        assert!(w.write_str("abc").is_ok());
+        assert!(w.write_str("de").is_ok());
+        assert!(w.write_str("f").is_err(), "budget exhausted must error");
+        assert_eq!(w.buf, "abcde");
+    }
+
+    #[test]
+    fn capped_vec_errors_at_budget_and_json_maps_to_output_too_large() {
+        let mut w = CappedVec {
+            buf: Vec::new(),
+            remaining: 4,
+        };
+        assert!(w.write(b"1234").is_ok());
+        assert!(w.write(b"5").is_err());
+
+        let big = vec!["x".repeat(64); 4];
+        let err = json_capped(&big, 16).unwrap_err();
+        assert!(err.json().contains("output_too_large"), "{}", err.json());
+        // Uncapped succeeds.
+        assert!(json_capped(&big, 1 << 20).is_ok());
     }
 }

--- a/scripts/wasm-parity.cjs
+++ b/scripts/wasm-parity.cjs
@@ -165,7 +165,7 @@ async function main() {
   }
 
   try {
-    docray.extract(Buffer.from("cap-check"), "", 1);
+    docray.extract(Buffer.from("cap-check"), "", 1, 0);
     throw new Error("input cap did not reject an oversized input");
   } catch (error) {
     const envelope = JSON.parse(String(error));
@@ -187,7 +187,7 @@ async function main() {
     }
 
     const native = JSON.parse(nativeRun.stdout);
-    const wasm = JSON.parse(docray.extract(fs.readFileSync(fixturePath), "", 0));
+    const wasm = JSON.parse(docray.extract(fs.readFileSync(fixturePath), "", 0, 0));
     results.push({ fixture, ...compare(native, wasm) });
 
     // Lean output must match wasm-vs-native: same Rust renderer over the
@@ -201,7 +201,7 @@ async function main() {
     if (leanNative.status !== 0) {
       throw new Error(`native lean failed for ${fixture}: ${leanNative.stderr.trim()}`);
     }
-    const leanWasm = docray.extract_lean(fs.readFileSync(fixturePath), "element", 0);
+    const leanWasm = docray.extract_lean(fs.readFileSync(fixturePath), "element", 0, 0);
     const leanLines = { native: leanNative.stdout.split("\n").length, wasm: leanWasm.split("\n").length };
     const nNorm = leanNative.stdout.split("\n");
     const wNorm = leanWasm.split("\n");

--- a/web/worker.js
+++ b/web/worker.js
@@ -66,9 +66,12 @@ self.onmessage = async ev => {
   try {
     const docray = await initOnce();
     const t0 = performance.now();
+    // Output budget enforced INSIDE the wasm during serialization (a
+    // pathological PDF can't OOM the worker by materializing a huge string);
+    // the post-hoc units check below stays as a second belt.
     const json = cmd === "extract_lean"
-      ? docray.extract_lean(new Uint8Array(bytes), granularity || "", cap || 0)
-      : docray.extract(new Uint8Array(bytes), granularity || "", cap || 0);
+      ? docray.extract_lean(new Uint8Array(bytes), granularity || "", cap || 0, OUTPUT_CAP_UNITS * 2)
+      : docray.extract(new Uint8Array(bytes), granularity || "", cap || 0, OUTPUT_CAP_UNITS * 2);
     if (json.length > OUTPUT_CAP_UNITS) {
       postMessage({ id, ok: false, error: { code: "output_too_large",
         message: "extraction produced " + json.length + " code units (cap " + OUTPUT_CAP_UNITS + ")" } });


### PR DESCRIPTION
Low-impact hardening from a security scan: the browser engine's output cap was checked *after* `serde_json::to_string`/`to_lean` already materialized the full string in WASM memory — a crafted PDF could OOM/trap the worker before the cap ran. Contained (the playground retires and respawns the worker; no cross-origin effect), but it violated our cap-prevents-not-observes principle.

Fix: `to_lean` is now streamed through `write_lean<W: fmt::Write>`; docray-wasm renders via byte-capped writers that abort with `output_too_large` mid-serialization. `extract`/`extract_lean` take a `max_output_bytes` param (0 = uncapped); the worker passes it. Writer unit tests added; wasm parity + browser e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)