### PR TITLE
Make the text hierarchy optional and granularity capability-aware

### DIFF
--- a/.superpowers/sdd/phase0-report.md
+++ b/.superpowers/sdd/phase0-report.md
@@ -1,0 +1,56 @@
+# Phase 0 implementation report
+
+Branch: `feature/optional-hierarchy`
+
+Implementation commit: `27a2595` (`feat: add capability-aware text hierarchy`)
+
+## Change evidence
+
+1. `TextElement.lines` is now `Option<Vec<Line>>` with serde defaulting and
+   omission for `None`. PDF extraction always constructs `Some(lines)`.
+   `optional_lines_preserve_old_json_shape_and_omit_when_absent` proves the
+   old literal JSON shape is unchanged for `Some`, `None` omits the key, old
+   JSON deserializes to `Some`, and a missing key deserializes to `None`.
+2. Word projection treats a missing hierarchy as an empty word sequence. The
+   defensive behavior is documented at the projection and
+   `word_projection_with_missing_hierarchy_has_no_words` proves both JSON
+   `"words": []` and a lean `T` header with no `w` records.
+3. `Extractor` now requires explicit `capabilities() -> Capabilities` and
+   `Capabilities` remains an extensible struct with only
+   `finest_granularity`. `Granularity::rank()` orders Element < Word < Char.
+   `PdfExtractor` explicitly advertises Char.
+4. `ExtractError::GranularityUnavailable { requested, finest }` exposes the
+   stable `granularity_unavailable` code. `check_granularity` treats an absent
+   request as Char and rejects requests finer than the extractor capability.
+   Element-only stub tests cover None, Char, Word, Element, and lean's
+   normalized Element request; the PDF capability test covers every request.
+5. The CLI checks capabilities before extraction and maps the new error to
+   exit 8 through a directly tested mapping seam. The server recognizes worker
+   exits 2 through 8 and maps `granularity_unavailable` to HTTP 400, with unit
+   tests for both mappings.
+6. Public CLI and HTTP error tables document the new stable error without
+   naming future formats. `AGENTS.md` includes exit 8 and the new error code.
+
+## PDF byte-identity proof
+
+- PDF construction always supplies `Some(lines)`, so serde emits the same
+  `lines` key, in the same field position, with the same nested representation.
+- The model test compares serialization against a complete literal of the old
+  `TextElement` JSON shape.
+- The full workspace golden suite passed, including `goldens_match`, compact
+  goldens, lean goldens, and extraction determinism.
+- After running the fixture generator, `git diff --exit-code -- testdata/`
+  exited 0. No fixture or golden changed.
+
+## Gates
+
+- `cargo fmt --check` — passed.
+- `cargo clippy --all-targets -- -D warnings` — passed.
+- `cargo build -p docray-cli` — passed.
+- `cargo test --workspace` — passed, including all socket-backed server tests.
+- `cargo run -p docray-pdf --example gen_fixtures` — passed.
+- `git diff --exit-code -- testdata/` — passed; empty diff.
+
+## Deviations
+
+None.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,10 @@ Docker build/smoke test.
 4. **Coordinates** are top-left origin, y-down, PDF points, **after page
    rotation**, rounded via `round3`. Compact granularities round to 1
    decimal.
-5. **Stable error contract.** CLI exit codes (0/2/3/4/5/6/7) and error code
+5. **Stable error contract.** CLI exit codes (0/2/3/4/5/6/7/8) and error code
    strings (`unsupported_format`, `encrypted_pdf`, `parse_failure`,
    `io_error`, `too_many_pages`, `bad_format`, `timeout`, `crash`,
-   `output_too_large`) are
+   `output_too_large`, `granularity_unavailable`) are
    parsed by machines. Do not change them; add new ones deliberately.
 6. **Hostile input is the norm.** The server must never parse a PDF
    in-process — extraction happens in the spawned CLI worker under a

--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -35,6 +35,7 @@ with a stable exit code:
 | 5 | `io_error` | file unreadable / missing |
 | 6 | `too_many_pages` | over the `--max-pages` cap |
 | 7 | `bad_format` | invalid format, or lean requested with `char` granularity |
+| 8 | `granularity_unavailable` | the requested granularity is finer than this source provides |
 
 Anything else (e.g. 101, or death by signal) means the parser crashed —
 treat it as `crash`. The server does exactly this mapping.

--- a/book/src/http-api.md
+++ b/book/src/http-api.md
@@ -49,6 +49,7 @@ is instance-local — see
 |---:|---|---|
 | 400 | `bad_granularity` | invalid `granularity` value |
 | 400 | `bad_format` | invalid `format`, or lean combined with `char` |
+| 400 | `granularity_unavailable` | the requested granularity is finer than this source provides |
 | 400 | `bad_multipart` / `missing_file` | malformed upload |
 | 413 | `too_large` / `too_many_pages` | over sync caps — use jobs |
 | 415 | `unsupported_format` | not a PDF |

--- a/crates/docray-cli/src/main.rs
+++ b/crates/docray-cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use docray_core::{sniff_format, ExtractError, Extractor, Format};
+use docray_core::{check_granularity, sniff_format, ExtractError, Extractor, Format};
 use docray_model::{GranularExtraction, Granularity, OutputFormat};
 use docray_pdf::PdfExtractor;
 use std::process::ExitCode;
@@ -71,7 +71,11 @@ fn run_extract(
         Err(e) => return fail(&ExtractError::Io(format!("{file}: {e}"))),
     };
     let result = match sniff_format(&bytes) {
-        Some(Format::Pdf) => PdfExtractor.extract(&bytes, max_pages),
+        Some(Format::Pdf) => {
+            let extractor = PdfExtractor;
+            check_granularity(&extractor.capabilities(), granularity)
+                .and_then(|()| extractor.extract(&bytes, max_pages))
+        }
         None => Err(ExtractError::UnsupportedFormat),
     };
     match result {
@@ -123,12 +127,30 @@ fn fail(e: &ExtractError) -> ExitCode {
         "{}",
         serde_json::json!({ "error": { "code": e.code(), "message": e.to_string() } })
     );
-    let code: u8 = match e {
+    ExitCode::from(extract_error_exit_code(e))
+}
+
+fn extract_error_exit_code(e: &ExtractError) -> u8 {
+    match e {
         ExtractError::UnsupportedFormat => 2,
         ExtractError::EncryptedPdf => 3,
         ExtractError::ParseFailure(_) => 4,
         ExtractError::Io(_) => 5,
         ExtractError::TooManyPages { .. } => 6,
-    };
-    ExitCode::from(code)
+        ExtractError::GranularityUnavailable { .. } => 8,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn granularity_unavailable_maps_to_exit_8() {
+        let error = ExtractError::GranularityUnavailable {
+            requested: Granularity::Word,
+            finest: Granularity::Element,
+        };
+        assert_eq!(extract_error_exit_code(&error), 8);
+    }
 }

--- a/crates/docray-core/src/error.rs
+++ b/crates/docray-core/src/error.rs
@@ -1,6 +1,8 @@
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+use docray_model::Granularity;
+
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum ExtractError {
     #[error("input is not a supported format")]
     UnsupportedFormat,
@@ -12,6 +14,11 @@ pub enum ExtractError {
     ParseFailure(String),
     #[error("io error: {0}")]
     Io(String),
+    #[error("requested {requested} granularity is unavailable; finest available is {finest}")]
+    GranularityUnavailable {
+        requested: Granularity,
+        finest: Granularity,
+    },
 }
 
 impl ExtractError {
@@ -22,6 +29,7 @@ impl ExtractError {
             ExtractError::TooManyPages { .. } => "too_many_pages",
             ExtractError::ParseFailure(_) => "parse_failure",
             ExtractError::Io(_) => "io_error",
+            ExtractError::GranularityUnavailable { .. } => "granularity_unavailable",
         }
     }
 }

--- a/crates/docray-core/src/lib.rs
+++ b/crates/docray-core/src/lib.rs
@@ -5,8 +5,87 @@ mod sniff;
 pub use error::ExtractError;
 pub use sniff::{sniff_format, Format};
 
-use docray_model::Extraction;
+use docray_model::{Extraction, Granularity};
+
+/// Capabilities of an extraction backend. Keeping this extensible as a struct
+/// allows future independent capability axes without changing the trait method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Capabilities {
+    pub finest_granularity: Granularity,
+}
 
 pub trait Extractor {
+    fn capabilities(&self) -> Capabilities;
+
     fn extract(&self, bytes: &[u8], max_pages: Option<u32>) -> Result<Extraction, ExtractError>;
+}
+
+/// Rejects a request that needs a finer hierarchy than an extractor provides.
+/// An absent request is the frozen full/char-level response.
+pub fn check_granularity(
+    capabilities: &Capabilities,
+    requested: Option<Granularity>,
+) -> Result<(), ExtractError> {
+    let requested = requested.unwrap_or(Granularity::Char);
+    if requested.rank() > capabilities.finest_granularity.rank() {
+        Err(ExtractError::GranularityUnavailable {
+            requested,
+            finest: capabilities.finest_granularity,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ElementExtractor;
+
+    impl Extractor for ElementExtractor {
+        fn capabilities(&self) -> Capabilities {
+            Capabilities {
+                finest_granularity: Granularity::Element,
+            }
+        }
+
+        fn extract(
+            &self,
+            _bytes: &[u8],
+            _max_pages: Option<u32>,
+        ) -> Result<Extraction, ExtractError> {
+            unreachable!("capability gate tests do not extract")
+        }
+    }
+
+    #[test]
+    fn element_only_extractor_rejects_finer_and_implicit_requests() {
+        let capabilities = ElementExtractor.capabilities();
+        for (requested, effective) in [
+            (None, Granularity::Char),
+            (Some(Granularity::Char), Granularity::Char),
+            (Some(Granularity::Word), Granularity::Word),
+        ] {
+            assert_eq!(
+                check_granularity(&capabilities, requested),
+                Err(ExtractError::GranularityUnavailable {
+                    requested: effective,
+                    finest: Granularity::Element,
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn element_only_extractor_accepts_element_and_lean_equivalent() {
+        let capabilities = ElementExtractor.capabilities();
+        assert_eq!(
+            check_granularity(&capabilities, Some(Granularity::Element)),
+            Ok(())
+        );
+        // Lean requests are normalized to element granularity by entry points.
+        let lean_request = Some(Granularity::Element);
+        assert_eq!(check_granularity(&capabilities, lean_request), Ok(()));
+    }
 }

--- a/crates/docray-core/src/lib.rs
+++ b/crates/docray-core/src/lib.rs
@@ -78,14 +78,13 @@ mod tests {
     }
 
     #[test]
-    fn element_only_extractor_accepts_element_and_lean_equivalent() {
+    fn element_only_extractor_accepts_element_requests() {
+        // Lean entry points normalize their default to an explicit Element
+        // request before reaching this gate, so Element covers lean too.
         let capabilities = ElementExtractor.capabilities();
         assert_eq!(
             check_granularity(&capabilities, Some(Granularity::Element)),
             Ok(())
         );
-        // Lean requests are normalized to element granularity by entry points.
-        let lean_request = Some(Granularity::Element);
-        assert_eq!(check_granularity(&capabilities, lean_request), Ok(()));
     }
 }

--- a/crates/docray-core/tests/sniff.rs
+++ b/crates/docray-core/tests/sniff.rs
@@ -1,4 +1,5 @@
 use docray_core::{sniff_format, ExtractError, Format};
+use docray_model::Granularity;
 
 #[test]
 fn detects_pdf_magic_at_start() {
@@ -61,4 +62,12 @@ fn error_codes_are_stable_strings() {
         "parse_failure"
     );
     assert_eq!(ExtractError::Io("x".into()).code(), "io_error");
+    assert_eq!(
+        ExtractError::GranularityUnavailable {
+            requested: Granularity::Word,
+            finest: Granularity::Element,
+        }
+        .code(),
+        "granularity_unavailable"
+    );
 }

--- a/crates/docray-model/src/lib.rs
+++ b/crates/docray-model/src/lib.rs
@@ -80,7 +80,8 @@ pub struct TextElement {
     pub content: String,
     pub font: Font,
     pub color: TextColor,
-    pub lines: Vec<Line>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub lines: Option<Vec<Line>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -164,6 +165,15 @@ impl Granularity {
             Granularity::Element => "element",
             Granularity::Word => "word",
             Granularity::Char => "char",
+        }
+    }
+
+    /// Orders granularities from coarsest to finest.
+    pub const fn rank(self) -> u8 {
+        match self {
+            Granularity::Element => 0,
+            Granularity::Word => 1,
+            Granularity::Char => 2,
         }
     }
 }
@@ -637,10 +647,13 @@ fn compact_element(element: &Element, granularity: Granularity) -> CompactElemen
                 },
                 Granularity::Word => CompactTextContent::Word {
                     // Preserve the extractor's content-stream order; DPS does
-                    // not perform semantic reordering.
+                    // not perform semantic reordering. A missing hierarchy is
+                    // unreachable through capability-aware entry points for a
+                    // word request, but keep this projection defined defensively.
                     words: text
                         .lines
                         .iter()
+                        .flatten()
                         .flat_map(|line| line.words.iter())
                         .map(|word| {
                             let [x0, y0, x1, y1] = compact_bbox(&word.bbox);

--- a/crates/docray-model/tests/lean.rs
+++ b/crates/docray-model/tests/lean.rs
@@ -42,7 +42,7 @@ fn extraction() -> Extraction {
                         fill: Some([35, 31, 32]),
                         stroke: Some([255, 0, 0]),
                     },
-                    lines: vec![Line {
+                    lines: Some(vec![Line {
                         bbox: BBox {
                             x0: 1.04,
                             y0: 2.06,
@@ -60,7 +60,7 @@ fn extraction() -> Extraction {
                             },
                             chars: vec![],
                         }],
-                    }],
+                    }]),
                 }),
                 Element::Text(TextElement {
                     id: "p1-e1".into(),
@@ -81,7 +81,7 @@ fn extraction() -> Extraction {
                         fill: Some([0, 0, 0]),
                         stroke: Some([255, 0, 0]),
                     },
-                    lines: vec![],
+                    lines: Some(vec![]),
                 }),
                 Element::Image(ImageElement {
                     id: "p1-e2".into(),
@@ -165,6 +165,29 @@ fn word_lean_nests_escaped_words_under_text_elements() {
     assert_eq!(lines[4], "T 1 2.1 30 40.1 A_B_C 12.1 bi#231f20");
     assert_eq!(lines[5], "w 1 2.1 30 40.1 a\\\\b\\nc\td");
     assert_eq!(lines[6], "T 41 42 43 44 - 9 -");
+}
+
+#[test]
+fn word_projection_with_missing_hierarchy_has_no_words() {
+    let mut extraction = extraction();
+    let Element::Text(text) = &mut extraction.pages[0].elements[0] else {
+        panic!("sample text element missing");
+    };
+    text.lines = None;
+
+    let projection = extraction.with_granularity(Granularity::Word);
+    let value = serde_json::to_value(&projection).unwrap();
+    assert_eq!(
+        value["pages"][0]["elements"][0]["words"],
+        serde_json::json!([])
+    );
+
+    let GranularExtraction::Compact(compact) = projection else {
+        panic!("word granularity must be compact");
+    };
+    let rendered = compact.to_lean();
+    assert!(rendered.contains("\nT 1 2.1 30 40.1 A_B_C 12.1 bi#231f20\n"));
+    assert!(!rendered.lines().any(|line| line.starts_with("w ")));
 }
 
 /// A hostile PDF's annotation URI must not be able to inject fake element

--- a/crates/docray-model/tests/schema.rs
+++ b/crates/docray-model/tests/schema.rs
@@ -41,7 +41,7 @@ fn sample() -> Extraction {
                     fill: Some([0, 0, 0]),
                     stroke: None,
                 },
-                lines: vec![Line {
+                lines: Some(vec![Line {
                     bbox: BBox {
                         x0: 1.0,
                         y0: 2.0,
@@ -68,7 +68,7 @@ fn sample() -> Extraction {
                             unicode: 72,
                         }],
                     }],
-                }],
+                }]),
             })],
         }],
     }
@@ -93,6 +93,29 @@ fn roundtrips() {
     let json = serde_json::to_string(&sample()).unwrap();
     let back: Extraction = serde_json::from_str(&json).unwrap();
     assert_eq!(serde_json::to_string(&back).unwrap(), json);
+}
+
+#[test]
+fn optional_lines_preserve_old_json_shape_and_omit_when_absent() {
+    let extraction = sample();
+    let Element::Text(text) = &extraction.pages[0].elements[0] else {
+        panic!("sample text element missing");
+    };
+    let old_shape = r#"{"id":"p1-e0","bbox":{"x0":1.0,"y0":2.0,"x1":3.0,"y1":4.0},"content":"Hi","font":{"name":"Helvetica","size":12.0,"bold":false,"italic":false},"color":{"fill":[0,0,0],"stroke":null},"lines":[{"bbox":{"x0":1.0,"y0":2.0,"x1":3.0,"y1":4.0},"baseline_y":3.5,"words":[{"content":"Hi","bbox":{"x0":1.0,"y0":2.0,"x1":3.0,"y1":4.0},"chars":[{"content":"H","bbox":{"x0":1.0,"y0":2.0,"x1":2.0,"y1":4.0},"unicode":72}]}]}]}"#;
+    assert_eq!(serde_json::to_string(text).unwrap(), old_shape);
+
+    let mut without_lines = text.clone();
+    without_lines.lines = None;
+    let value = serde_json::to_value(without_lines).unwrap();
+    assert!(!value.as_object().unwrap().contains_key("lines"));
+
+    let decoded: TextElement = serde_json::from_str(old_shape).unwrap();
+    assert!(decoded.lines.is_some());
+
+    let mut missing_lines: serde_json::Value = serde_json::from_str(old_shape).unwrap();
+    missing_lines.as_object_mut().unwrap().remove("lines");
+    let decoded: TextElement = serde_json::from_value(missing_lines).unwrap();
+    assert_eq!(decoded.lines, None);
 }
 
 #[test]

--- a/crates/docray-pdf/src/extract.rs
+++ b/crates/docray-pdf/src/extract.rs
@@ -6,7 +6,7 @@
 // rather than taking down the service.
 use crate::{bind::pdfium, coords::PageSpace};
 use docray_core::grouping::{group_into_lines, RawChar};
-use docray_core::{sniff_format, ExtractError, Extractor, Format};
+use docray_core::{sniff_format, Capabilities, ExtractError, Extractor, Format};
 use docray_model::*;
 use pdfium_render::prelude::*;
 use sha2::{Digest, Sha256};
@@ -18,6 +18,12 @@ const SCANNED_IMAGE_COVERAGE_THRESHOLD: f64 = 0.85;
 pub struct PdfExtractor;
 
 impl Extractor for PdfExtractor {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            finest_granularity: Granularity::Char,
+        }
+    }
+
     fn extract(&self, bytes: &[u8], max_pages: Option<u32>) -> Result<Extraction, ExtractError> {
         if sniff_format(bytes) != Some(Format::Pdf) {
             return Err(ExtractError::UnsupportedFormat);
@@ -435,7 +441,7 @@ fn text_element(
             italic: font.is_italic() || name_lower.contains("italic"),
         },
         color: TextColor { fill, stroke },
-        lines,
+        lines: Some(lines),
     }))
 }
 

--- a/crates/docray-pdf/tests/forms.rs
+++ b/crates/docray-pdf/tests/forms.rs
@@ -57,7 +57,10 @@ fn recursively_flattens_form_objects_in_page_space() {
     // Local baseline (10,20) under [2 0 0 2 100 300] becomes PDF-space
     // (120,340), or top-left baseline y=792-340=452.
     near(scaled.bbox.x0, 120.0);
-    near(scaled.lines[0].baseline_y, 452.0);
+    near(
+        scaled.lines.as_ref().expect("PDF hierarchy missing")[0].baseline_y,
+        452.0,
+    );
     assert_eq!(scaled.font.size, 20.0, "10pt text under 2x form scale");
 
     let path = page
@@ -111,7 +114,10 @@ fn recursively_flattens_form_objects_in_page_space() {
     // (10,20) + inner /Matrix (5,7) + inner cm (20,40) + outer cm
     // (300,500) = PDF-space baseline (335,567), top-left y=225.
     near(nested.bbox.x0, 335.0);
-    near(nested.lines[0].baseline_y, 225.0);
+    near(
+        nested.lines.as_ref().expect("PDF hierarchy missing")[0].baseline_y,
+        225.0,
+    );
 
     let order_text = texts
         .iter()
@@ -120,7 +126,10 @@ fn recursively_flattens_form_objects_in_page_space() {
     // Text local (0,10), then inner cm (30,10), then outer [2 0 0 2 400 100]
     // gives PDF baseline (460,140), or top-left y=652.
     near(order_text.bbox.x0, 460.0);
-    near(order_text.lines[0].baseline_y, 652.0);
+    near(
+        order_text.lines.as_ref().expect("PDF hierarchy missing")[0].baseline_y,
+        652.0,
+    );
 
     let order_path = page
         .elements

--- a/crates/docray-pdf/tests/golden.rs
+++ b/crates/docray-pdf/tests/golden.rs
@@ -249,7 +249,7 @@ fn rotated_page_dims_and_coords_are_post_rotation() {
         match el {
             docray_model::Element::Text(t) => {
                 check(&t.bbox);
-                for l in &t.lines {
+                for l in t.lines.as_ref().expect("PDF hierarchy missing") {
                     check(&l.bbox);
                 }
             }

--- a/crates/docray-pdf/tests/text.rs
+++ b/crates/docray-pdf/tests/text.rs
@@ -1,5 +1,5 @@
-use docray_core::Extractor;
-use docray_model::Element;
+use docray_core::{check_granularity, Extractor};
+use docray_model::{Element, Granularity};
 use docray_pdf::PdfExtractor;
 
 /// cargo runs test binaries with CWD = crate dir, so bind()'s relative
@@ -48,10 +48,14 @@ fn extracts_text_hierarchy_from_simple_pdf() {
 
     // "Hello World" -> one line, two words, chars have boxes.
     let hello = texts.iter().find(|t| t.content.contains("Hello")).unwrap();
-    assert_eq!(hello.lines.len(), 1);
-    assert_eq!(hello.lines[0].words.len(), 2);
-    assert_eq!(hello.lines[0].words[0].content, "Hello");
-    let c0 = &hello.lines[0].words[0].chars[0];
+    let lines = hello
+        .lines
+        .as_ref()
+        .expect("PDF text must include the full hierarchy");
+    assert_eq!(lines.len(), 1);
+    assert_eq!(lines[0].words.len(), 2);
+    assert_eq!(lines[0].words[0].content, "Hello");
+    let c0 = &lines[0].words[0].chars[0];
     assert_eq!(c0.content, "H");
     assert!(c0.bbox.x1 > c0.bbox.x0 && c0.bbox.y1 > c0.bbox.y0);
 
@@ -62,7 +66,7 @@ fn extracts_text_hierarchy_from_simple_pdf() {
     // Baseline derives from each char's origin y (flipped to top-left space),
     // so it must sit within the line's glyph box — near the bottom for this
     // ascender-only text. Pins the F4 origin-based baseline against regression.
-    let baseline = hello.lines[0].baseline_y;
+    let baseline = lines[0].baseline_y;
     assert!(
         baseline >= hello.bbox.y0 && baseline <= hello.bbox.y1 + 1.0,
         "baseline {baseline} outside bbox {:?}",
@@ -86,6 +90,19 @@ fn extracts_text_hierarchy_from_simple_pdf() {
         };
         id == &format!("p1-e{i}")
     }));
+}
+
+#[test]
+fn pdf_capabilities_accept_every_granularity() {
+    let capabilities = PdfExtractor.capabilities();
+    for requested in [
+        None,
+        Some(Granularity::Char),
+        Some(Granularity::Word),
+        Some(Granularity::Element),
+    ] {
+        assert_eq!(check_granularity(&capabilities, requested), Ok(()));
+    }
 }
 
 #[test]

--- a/crates/docray-server/src/http.rs
+++ b/crates/docray-server/src/http.rs
@@ -175,6 +175,7 @@ pub fn outcome_to_response(outcome: WorkerOutcome, format: OutputFormat) -> Resp
             .into_response(),
         WorkerOutcome::Failed { code, message } => {
             let status = match code.as_str() {
+                "granularity_unavailable" => StatusCode::BAD_REQUEST,
                 "unsupported_format" => StatusCode::UNSUPPORTED_MEDIA_TYPE,
                 "encrypted_pdf" | "parse_failure" => StatusCode::UNPROCESSABLE_ENTITY,
                 "too_many_pages" => StatusCode::PAYLOAD_TOO_LARGE,
@@ -484,5 +485,17 @@ mod tests {
     fn invalid_format_query_has_stable_error_code() {
         let error = requested_output(Ok(query(None, Some("toon")))).unwrap_err();
         assert_eq!(error.code, "bad_format");
+    }
+
+    #[test]
+    fn unavailable_granularity_is_a_bad_request() {
+        let response = outcome_to_response(
+            WorkerOutcome::Failed {
+                code: "granularity_unavailable".into(),
+                message: "requested word granularity is unavailable".into(),
+            },
+            OutputFormat::Json,
+        );
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/docray-server/src/worker.rs
+++ b/crates/docray-server/src/worker.rs
@@ -157,7 +157,7 @@ pub async fn run_extraction(
     match status {
         Ok(s) if s.success() => WorkerOutcome::Success(out),
         Ok(s) => match s.code() {
-            Some(code @ 2..=7) => {
+            Some(code) if is_structured_error_exit(code) => {
                 let parsed: Option<Value> = serde_json::from_slice(&err).ok();
                 let (c, m) = parsed
                     .as_ref()
@@ -182,5 +182,20 @@ pub async fn run_extraction(
             _ => WorkerOutcome::Crashed,
         },
         Err(_) => WorkerOutcome::Crashed,
+    }
+}
+
+fn is_structured_error_exit(code: i32) -> bool {
+    (2..=8).contains(&code)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_structured_error_exit;
+
+    #[test]
+    fn stable_worker_error_exit_range_includes_granularity_unavailable() {
+        assert!(is_structured_error_exit(8));
+        assert!(!is_structured_error_exit(9));
     }
 }


### PR DESCRIPTION
## What

- `TextElement.lines` is now `Option<Vec<Line>>`. `Some(lines)` serializes byte-identically to the previous shape (proven by a literal-comparison test); `None` omits the key. Old JSON deserializes unchanged.
- `Extractor` gains `capabilities()` returning a `Capabilities` struct (`finest_granularity`). `PdfExtractor` advertises `char`.
- New stable error `granularity_unavailable` (`ExtractError::GranularityUnavailable`), returned when a request needs a finer hierarchy than the source provides: CLI exit code 8, HTTP 400. A central `check_granularity` gate runs before extraction; lean's implicit default is normalized to `element` before the gate.
- Word-granularity projection of an element without a hierarchy is defined defensively (empty `words`, lean `T` header with no `w` records) and unit-tested, though unreachable through capability-checked entry points.
- Docs: CLI exit-code table, HTTP error table, and AGENTS.md stable-error list updated.

## Contract impact

- **No observable change for PDF.** The no-parameter response remains schema 1.1 byte-identical; goldens are untouched (`git diff testdata/` is empty; fixture regeneration produced zero diffs).
- `granularity_unavailable` is unreachable for PDF (finest = char) but is part of the stable error contract from this PR on.

## Golden changes

None — that is the point of this PR and the suite proves it.

## Checks

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace` (all green), `gen_fixtures` deterministic with empty `testdata/` diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)