### PR TITLE
PPTX in the browser playground (structure schematic)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,7 @@ dependencies = [
  "docray-core",
  "docray-model",
  "docray-pdf",
+ "docray-pptx",
  "serde",
  "serde_json",
  "wasm-bindgen",

--- a/book/src/playground.md
+++ b/book/src/playground.md
@@ -11,17 +11,19 @@ There are two ways to use the playground:
 `docray-server` embeds a browser workbench at **`/playground`** — the fastest
 way to understand what docray extracts and to debug a specific document.
 
-Drop a PDF on it and every page appears with:
+Drop a PDF or PPTX on it and every page or slide appears with:
 
 - **A thumbnail rail** for navigation (arrow keys work; scanned pages carry a
   badge).
-- **Two independent panels**, each switchable between five lenses:
-  - **source** — the rendered page
+- **Two independent panels**, each switchable between six lenses:
+  - **source** — the rendered PDF page, or a clearly labeled PPTX structure
+    schematic reconstructed from docray's extraction (not a visual slide render)
   - **boxes** — the page with filled, color-coded bounding boxes
     (<span style="color:#5cc8ff">text</span>,
     <span style="color:#ff7ac2">image</span>,
     <span style="color:#9dff70">path</span>,
-    <span style="color:#ffd166">annotation</span>)
+    <span style="color:#ffd166">annotation</span>,
+    <span style="color:#c79cff">table</span>)
   - **x-ray** — the page dimmed with wireframe boxes over it
   - **text** — the extracted content, element by element
   - **json** — the page's JSON, syntax-highlighted, with a copy button
@@ -38,7 +40,8 @@ Hover any box for its content, font, and coordinates.
 ## Notes
 
 - The page loads pdf.js and fonts from CDNs, so the **browser** needs
-  internet access — the extraction API itself does not.
+  internet access for PDF rendering and web fonts — the extraction API itself
+  does not. PPTX source views are schematics drawn from extraction data.
 - Uploads go to the server's own `/v1/extract`; nothing leaves your
   deployment.
 - The UI is a single self-contained HTML file compiled into the server

--- a/book/src/quickstart.md
+++ b/book/src/quickstart.md
@@ -46,9 +46,10 @@ docray-server listening on http://localhost:41619
 playground UI:        http://localhost:41619/playground
 ```
 
-Open the playground, drop a PDF on it, and you'll see every page rendered
-beside its extracted bounding boxes with live JSON. It is the fastest way to
-build intuition for what docray emits — see [the playground](playground.md).
+Open the playground and drop a PDF or PPTX on it. PDFs appear as rendered
+pages; PPTX slides appear as clearly labeled structure schematics reconstructed
+from extraction data, not visual slide renders. Both sit beside extracted
+bounding boxes and live JSON — see [the playground](playground.md).
 
 Extract over HTTP:
 

--- a/crates/docray-server/assets/playground.html
+++ b/crates/docray-server/assets/playground.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>docray · Playground</title>
+<link rel="icon" href="data:,">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;1,400&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
@@ -22,6 +23,7 @@
     --c-image: #ff7ac2;
     --c-path: #9dff70;
     --c-annotation: #ffd166;
+    --c-table: #c79cff;
     --mono: "IBM Plex Mono", ui-monospace, monospace;
     --serif: "Instrument Serif", serif;
   }
@@ -157,10 +159,12 @@
   .chip.on[data-t="image"] { color: var(--c-image); border-color: currentColor; }
   .chip.on[data-t="path"] { color: var(--c-path); border-color: currentColor; }
   .chip.on[data-t="annotation"] { color: var(--c-annotation); border-color: currentColor; }
+  .chip.on[data-t="table"] { color: var(--c-table); border-color: currentColor; }
   .chip .dot[data-t="text"] { background: var(--c-text); }
   .chip .dot[data-t="image"] { background: var(--c-image); }
   .chip .dot[data-t="path"] { background: var(--c-path); }
   .chip .dot[data-t="annotation"] { background: var(--c-annotation); }
+  .chip .dot[data-t="table"] { background: var(--c-table); }
   .badge-scan {
     font-size: 9.5px; letter-spacing: 0.16em; text-transform: uppercase;
     color: #241a08; background: var(--c-annotation);
@@ -188,12 +192,20 @@
   .film-frame { position: relative; flex: none; box-shadow: 0 0 0 1px var(--hair), 0 18px 50px -18px rgba(0,0,0,0.85), 0 0 60px -20px rgba(232,163,61,0.18); }
   .film-frame canvas { display: block; background: var(--film); }
   .film-frame.xray canvas { filter: grayscale(0.9) brightness(0.42) contrast(0.9); }
+  .schematic-caption {
+    position: absolute; left: 0; right: 0; bottom: 0; z-index: 3;
+    padding: 7px 10px; pointer-events: none;
+    color: #241a08; background: rgba(232,163,61,0.96);
+    font-size: 9px; font-weight: 600; letter-spacing: 0.08em;
+    text-align: center; text-transform: uppercase;
+  }
   .overlay { position: absolute; inset: 0; }
   .overlay rect { stroke-width: 1; vector-effect: non-scaling-stroke; cursor: crosshair; transition: fill-opacity 0.12s; }
   .overlay rect.t-text       { stroke: var(--c-text);       fill: var(--c-text); }
   .overlay rect.t-image      { stroke: var(--c-image);      fill: var(--c-image); }
   .overlay rect.t-path       { stroke: var(--c-path);       fill: var(--c-path); }
   .overlay rect.t-annotation { stroke: var(--c-annotation); fill: var(--c-annotation); }
+  .overlay rect.t-table      { stroke: var(--c-table);      fill: var(--c-table); }
   .overlay.filled rect { fill-opacity: 0.16; }
   .overlay.wire rect { fill-opacity: 0; }
   .overlay rect:hover { fill-opacity: 0.38; }
@@ -212,6 +224,7 @@
   .tv-el[data-t="image"] { border-left-color: var(--c-image); }
   .tv-el[data-t="path"] { border-left-color: var(--c-path); }
   .tv-el[data-t="annotation"] { border-left-color: var(--c-annotation); }
+  .tv-el[data-t="table"] { border-left-color: var(--c-table); }
   .tv-el.hid { display: none; }
 
   /* json view */
@@ -264,8 +277,8 @@
     </select>
   </div>
   <button class="btn" id="docjson" disabled>document json</button>
-  <button class="btn btn-amber" id="pick">upload pdf</button>
-  <input type="file" id="file" accept="application/pdf">
+  <button class="btn btn-amber" id="pick">upload pdf or pptx</button>
+  <input type="file" id="file" accept="application/pdf,application/vnd.openxmlformats-officedocument.presentationml.presentation,.pdf,.pptx">
 </header>
 <div class="ruler"></div>
 <div class="status" id="status"></div>
@@ -274,9 +287,9 @@
   <div class="drop" id="drop">
     <i class="corner c1"></i><i class="corner c2"></i><i class="corner c3"></i><i class="corner c4"></i>
     <h1>Put a document <em>on the table</em>.</h1>
-    <p>Two panels, five lenses — source, boxes, x-ray, text, json.</p>
+    <p>Two panels, six lenses — source, boxes, x-ray, text, json, llm format.</p>
     <p>Click any box and the JSON finds itself.</p>
-    <p class="hint">drop a pdf anywhere · or click to browse</p>
+    <p class="hint">drop a pdf or pptx anywhere · or click to browse</p>
   </div>
 </div>
 
@@ -313,7 +326,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc =
   "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.10.38/pdf.worker.min.mjs";
 
 const $ = (s, r) => (r || document).querySelector(s);
-const TYPES = ["text", "image", "path", "annotation"];
+const TYPES = ["text", "image", "path", "annotation", "table"];
 const VIEWS = [
   ["source", "source"], ["boxes", "boxes"], ["xray", "x-ray"],
   ["text", "text"], ["json", "json"], ["lean", "llm format"],
@@ -323,7 +336,7 @@ const VIEWS = [
 // flight for an older generation abandons before touching DOM or caches.
 const state = {
   gen: 0, file: null, fileName: "",
-  extraction: null, pdf: null,
+  extraction: null, pdf: null, format: null,
   pageIdx: 0, zoom: 1,
   filters: new Set(TYPES),
   panelModes: ["source", "boxes"],
@@ -354,6 +367,18 @@ document.addEventListener("drop", e => {
   if (f) load(f);
 });
 $("#gran").onchange = () => { if (state.file) load(state.file, state.pageIdx); };
+
+async function sniffFileFormat(file) {
+  const bytes = new Uint8Array(await file.slice(0, 1028).arrayBuffer());
+  if (bytes.length >= 4 && bytes[0] === 0x50 && bytes[1] === 0x4b &&
+      bytes[2] === 0x03 && bytes[3] === 0x04) return "pptx";
+  const end = Math.min(bytes.length - 5, 1023);
+  for (let i = 0; i <= end; i += 1) {
+    if (bytes[i] === 0x25 && bytes[i + 1] === 0x50 && bytes[i + 2] === 0x44 &&
+        bytes[i + 3] === 0x46 && bytes[i + 4] === 0x2d) return "pdf";
+  }
+  return "other";
+}
 
 /* ── extraction engines ──
    "server": POST to this deployment's /v1/extract (native speed, subprocess
@@ -491,8 +516,9 @@ async function serverExtract(file, gran, signal) {
 }
 
 async function probeEngines() {
+  const staticTry = /\/try\/(?:index\.html)?$/.test(location.pathname);
   const [server, browser] = await Promise.all([
-    fetch("/healthz").then(r => r.ok).catch(() => false),
+    staticTry ? Promise.resolve(false) : fetch("/healthz").then(r => r.ok).catch(() => false),
     fetch("wasm/docray_wasm.js", { method: "HEAD" }).then(r => r.ok).catch(() => false),
   ]);
   if (server) engines.available.push("server");
@@ -529,7 +555,20 @@ async function load(file, keepPageIdx) {
   // The current document is NOT torn down yet: a failed upload must leave the
   // previous workbench fully functional. Teardown happens on success below.
 
-  const gran = $("#gran").value;
+  let format;
+  try {
+    format = await sniffFileFormat(file);
+  } catch (e) {
+    if (gen !== state.gen) return;
+    status("file read failed · " + e.message, true);
+    restoreRetainedDocument(gen);
+    return;
+  }
+  if (gen !== state.gen || ctrl.signal.aborted) return;
+  // PPTX is element-native: requesting char/word would correctly produce the
+  // stable granularity_unavailable error, so the playground selects the
+  // supported lens before dispatching to either engine.
+  const gran = format === "pptx" ? "element" : $("#gran").value;
   status("extracting · " + gran + " …");
   $("#status").classList.add("blink");
 
@@ -561,20 +600,22 @@ async function load(file, keepPageIdx) {
   }
   if (gen !== state.gen) return;
 
-  let pdf;
-  try {
-    const data = new Uint8Array(await file.arrayBuffer());
-    if (gen !== state.gen || ctrl.signal.aborted) return; // superseded during read
-    // isEvalSupported: defense in depth on top of the >=4.2.67 pin.
-    pdf = await pdfjsLib.getDocument({ data, isEvalSupported: false }).promise;
-  } catch (e) {
-    if (gen !== state.gen) return;
-    $("#status").classList.remove("blink");
-    status("pdf render failed · " + e.message, true);
-    restoreRetainedDocument(gen);
-    return;
+  let pdf = null;
+  if (format === "pdf") {
+    try {
+      const data = new Uint8Array(await file.arrayBuffer());
+      if (gen !== state.gen || ctrl.signal.aborted) return; // superseded during read
+      // isEvalSupported: defense in depth on top of the >=4.2.67 pin.
+      pdf = await pdfjsLib.getDocument({ data, isEvalSupported: false }).promise;
+    } catch (e) {
+      if (gen !== state.gen) return;
+      $("#status").classList.remove("blink");
+      status("pdf render failed · " + e.message, true);
+      restoreRetainedDocument(gen);
+      return;
+    }
+    if (gen !== state.gen) { pdf.destroy(); return; }
   }
-  if (gen !== state.gen) { pdf.destroy(); return; }
 
   const ms = Math.round(performance.now() - t0);
   $("#status").classList.remove("blink");
@@ -588,9 +629,15 @@ async function load(file, keepPageIdx) {
   state.extraction = extraction;
   state.leanCache = {}; // canonical lean bytes, keyed by granularity
   state.pdf = pdf;
+  state.format = format;
   state.pageIdx = Math.min(keepPageIdx || 0, extraction.pages.length - 1);
   state.zoom = 1;
   $("#zoom-pct").textContent = "fit";
+  const granularity = $("#gran");
+  granularity.value = gran;
+  for (const option of granularity.options) {
+    option.disabled = format === "pptx" && option.value !== "element";
+  }
 
   const els = extraction.pages.reduce((n, p) => n + p.elements.length, 0);
   $("#doc-name").textContent = file.name;
@@ -621,7 +668,7 @@ function fmtBytes(n) {
    retained document (blank frames, placeholder thumbs). Re-render everything
    under the new generation so the old document stays fully usable. */
 function restoreRetainedDocument(gen) {
-  if (!state.extraction || !state.pdf || gen !== state.gen) return;
+  if (!state.extraction || (!state.pdf && state.format !== "pptx") || gen !== state.gen) return;
   buildRail(gen);
   renderPanels(gen);
 }
@@ -655,7 +702,16 @@ function buildRail(gen) {
 }
 
 async function renderThumb(el, gen) {
-  if (gen !== state.gen || !state.pdf) return;
+  if (gen !== state.gen) return;
+  if (state.format === "pptx") {
+    const pageJson = state.extraction.pages[Number(el.dataset.idx)];
+    const rendered = schematicBitmap(pageJson, 92, 1, 1);
+    if (gen !== state.gen || !rendered) return;
+    const ph = el.querySelector(".ph");
+    if (ph) ph.replaceWith(rendered.canvas);
+    return;
+  }
+  if (!state.pdf) return;
   try {
     const page = await state.pdf.getPage(Number(el.dataset.idx) + 1);
     if (gen !== state.gen) return;
@@ -832,8 +888,11 @@ async function renderPanel(i, gen) {
       }
       const note = document.createElement("p");
       note.style.cssText = "color:var(--fg-dim);font-size:11px;margin:0 0 12px;max-width:60ch";
-      note.innerHTML = 'docray\u2019s <b style="color:var(--fg)">lean</b> format: the same content as the JSON, ' +
-        '25\u201340% fewer tokens \u2014 built for feeding documents to LLMs. ' +
+      const tokenCopy = state.format === "pptx"
+        ? "a compact canonical representation built for feeding presentations to LLMs. "
+        : "25\u201340% fewer tokens \u2014 built for feeding documents to LLMs. ";
+      note.innerHTML = '<b style="color:var(--amber);letter-spacing:.08em">LLM OPTIMIZED FORMAT</b><br>' +
+        'docray\u2019s <b style="color:var(--fg)">lean</b> format: the same content as the JSON, ' + tokenCopy +
         'Available via <code>--format lean</code> and <code>?format=lean</code>. ' +
         '<a href="https://f2-ai-inc.github.io/docray/output-formats.html" target="_blank" rel="noopener" style="color:var(--amber)">docs \u2197</a>' +
         ($("#gran").value === "char" ? "<br>(showing element granularity \u2014 lean has no char level)" : "");
@@ -902,6 +961,13 @@ async function renderPanel(i, gen) {
   canvas.style.height = rendered.cssH + "px";
   canvas.getContext("2d").drawImage(rendered.canvas, 0, 0);
 
+  if (state.format === "pptx") {
+    const caption = document.createElement("div");
+    caption.className = "schematic-caption";
+    caption.textContent = "STRUCTURE SCHEMATIC - reconstructed from docray's extraction, not a visual render of the slide.";
+    frame.appendChild(caption);
+  }
+
   if (mode !== "source") {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     svg.setAttribute("class", "overlay " + (mode === "boxes" ? "filled" : "wire"));
@@ -936,6 +1002,151 @@ function cachePut(key, entry) {
   }
 }
 
+const SCHEMATIC_COLORS = {
+  text: "#1376a8", image: "#b32674", path: "#3d7d24",
+  annotation: "#9a6a00", table: "#7650a8",
+};
+
+function validSchematicBBox(value) {
+  const b = normBBox(value);
+  if (!b) return null;
+  const nums = [b.x0, b.y0, b.x1, b.y1].map(Number);
+  if (!nums.every(Number.isFinite)) return null;
+  const [x0, y0, x1, y1] = nums;
+  if (x1 < x0 || y1 < y0) return null;
+  return { x0, y0, x1, y1 };
+}
+
+function schematicText(ctx, value, bbox, k, font) {
+  const text = String(value || "");
+  if (!text) return;
+  const x = bbox.x0 * k + 4;
+  const y = bbox.y0 * k + 4;
+  const width = Math.max((bbox.x1 - bbox.x0) * k - 8, 1);
+  const height = Math.max((bbox.y1 - bbox.y0) * k - 8, 1);
+  const size = Math.max(7, Math.min(24, Number(font && font.size || 12) * k));
+  const style = font && font.italic ? "italic " : "";
+  const weight = font && font.bold ? "600 " : "";
+  ctx.save();
+  ctx.beginPath();
+  ctx.rect(x, y, width, height);
+  ctx.clip();
+  ctx.fillStyle = "#29241e";
+  ctx.font = `${style}${weight}${size}px "IBM Plex Mono", monospace`;
+  ctx.textBaseline = "top";
+  const lineHeight = size * 1.25;
+  let cy = y;
+  for (const paragraph of text.split("\n")) {
+    let line = "";
+    for (const token of paragraph.split(/(\s+)/)) {
+      const candidate = line + token;
+      if (line && ctx.measureText(candidate).width > width) {
+        ctx.fillText(line, x, cy, width);
+        cy += lineHeight;
+        line = token.trimStart();
+        if (cy > y + height) break;
+      } else {
+        line = candidate;
+      }
+    }
+    if (cy > y + height) break;
+    if (line) ctx.fillText(line, x, cy, width);
+    cy += lineHeight;
+  }
+  ctx.restore();
+}
+
+function drawSchematicElement(ctx, pageJson, el, idx, k, roleByElement) {
+  const bbox = validSchematicBBox(el.bbox);
+  if (!bbox) return;
+  const color = SCHEMATIC_COLORS[el.type] || "#6f675b";
+  const x = bbox.x0 * k;
+  const y = bbox.y0 * k;
+  const width = Math.max((bbox.x1 - bbox.x0) * k, 0.5);
+  const height = Math.max((bbox.y1 - bbox.y0) * k, 0.5);
+  ctx.save();
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  ctx.strokeRect(x, y, width, height);
+  ctx.fillStyle = color + "12";
+  ctx.fillRect(x, y, width, height);
+
+  if (el.type === "text") {
+    schematicText(ctx, elementText(el), bbox, k, el.font);
+  } else if (el.type === "table") {
+    for (const cell of el.cells || []) {
+      const cb = validSchematicBBox(cell.bbox);
+      if (!cb) continue;
+      ctx.strokeRect(
+        cb.x0 * k, cb.y0 * k,
+        Math.max((cb.x1 - cb.x0) * k, 0.5),
+        Math.max((cb.y1 - cb.y0) * k, 0.5),
+      );
+      schematicText(ctx, cell.content, cb, k, cell.runs && cell.runs[0] && cell.runs[0].font);
+    }
+  } else {
+    const label = el.type === "annotation" && el.subtype ? el.subtype : el.type;
+    ctx.fillStyle = color;
+    ctx.font = '600 10px "IBM Plex Mono", monospace';
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(String(label || "element").toUpperCase(), x + width / 2, y + height / 2, Math.max(width - 8, 1));
+  }
+
+  const id = el.id || `p${pageJson.page_number}-e${idx}`;
+  const role = roleByElement.get(id);
+  if (role) {
+    ctx.font = '600 8px "IBM Plex Mono", monospace';
+    ctx.textAlign = "left";
+    ctx.textBaseline = "top";
+    const label = "ROLE " + String(role);
+    const labelWidth = Math.min(ctx.measureText(label).width + 8, Math.max(width, 1));
+    ctx.fillStyle = "rgba(22,19,15,0.88)";
+    ctx.fillRect(x, y, labelWidth, 14);
+    ctx.fillStyle = "#e8a33d";
+    ctx.fillText(label, x + 4, y + 3, Math.max(labelWidth - 8, 1));
+  }
+  ctx.restore();
+}
+
+function schematicBitmap(pageJson, fitWidth, zoom, dpr = window.devicePixelRatio || 1) {
+  const pageWidth = Number(pageJson.width);
+  const pageHeight = Number(pageJson.height);
+  if (!Number.isFinite(pageWidth) || !Number.isFinite(pageHeight) ||
+      pageWidth <= 0 || pageHeight <= 0) return null;
+  const cssW = Math.min(Math.max(fitWidth, 240), 900) * zoom;
+  const k = cssW / pageWidth;
+  const cssH = pageHeight * k;
+  const pixelW = Math.floor(cssW * dpr);
+  const pixelH = Math.floor(cssH * dpr);
+  // Refuse hostile slide dimensions before allocating a backing store.
+  if (pixelW < 1 || pixelH < 1 || pixelW > 16384 || pixelH > 16384 ||
+      pixelW * pixelH * 4 > CACHE_BYTE_CAP) return null;
+  const canvas = document.createElement("canvas");
+  canvas.width = pixelW;
+  canvas.height = pixelH;
+  const ctx = canvas.getContext("2d");
+  ctx.scale(dpr, dpr);
+  ctx.fillStyle = "#f2eee5";
+  ctx.fillRect(0, 0, cssW, cssH);
+  ctx.strokeStyle = "rgba(22,19,15,0.06)";
+  ctx.lineWidth = 1;
+  for (let x = 0; x < cssW; x += 24) {
+    ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, cssH); ctx.stroke();
+  }
+  for (let y = 0; y < cssH; y += 24) {
+    ctx.beginPath(); ctx.moveTo(0, y); ctx.lineTo(cssW, y); ctx.stroke();
+  }
+  const roleByElement = new Map(
+    (pageJson.hidden || [])
+      .filter(item => item.kind === "role" && item.element)
+      .map(item => [item.element, item.content]),
+  );
+  pageJson.elements.forEach((el, idx) =>
+    drawSchematicElement(ctx, pageJson, el, idx, k, roleByElement));
+  return { canvas, cssW, cssH, k };
+}
+
 /* Renders (or reuses) the current page's bitmap at the current zoom. */
 async function pageBitmap(gen, fitWidth) {
   // Everything key-relevant is captured at entry: if the user navigates or
@@ -943,13 +1154,18 @@ async function pageBitmap(gen, fitWidth) {
   const pageNo = state.pageIdx + 1;
   const pageJson = state.extraction.pages[state.pageIdx];
   const zoom = state.zoom;
-  const key = pageNo + "@" + zoom.toFixed(2) + "@" + Math.round(fitWidth);
+  const key = state.format + "@" + pageNo + "@" + zoom.toFixed(2) + "@" + Math.round(fitWidth);
   if (state.renderCache.has(key)) {
     // True LRU: re-insert on hit so hot entries survive eviction.
     const hit = state.renderCache.get(key);
     state.renderCache.delete(key);
     state.renderCache.set(key, hit);
     return hit;
+  }
+  if (state.format === "pptx") {
+    const entry = schematicBitmap(pageJson, fitWidth, zoom);
+    if (entry) cachePut(key, entry);
+    return entry;
   }
   try {
     const page = await state.pdf.getPage(pageNo);
@@ -1076,6 +1292,7 @@ function elementText(el) {
   return el.content !== undefined ? el.content
        : el.text !== undefined ? el.text
        : el.words ? el.words.map(w => Array.isArray(w) ? w[0] : w.content).join(" ")
+       : el.cells ? el.cells.map(cell => cell.content || "").filter(Boolean).join(" | ")
        : el.uri || "";
 }
 

--- a/crates/docray-server/assets/playground.html
+++ b/crates/docray-server/assets/playground.html
@@ -692,7 +692,10 @@ function buildRail(gen) {
     const t = document.createElement("div");
     t.className = "thumb" + (i === state.pageIdx ? " cur" : "");
     t.dataset.idx = i;
-    const ratio = p.width > 0 ? p.height / p.width : 1.294;
+    // Clamp the placeholder aspect ratio to match schematicBitmap's thumbnail
+    // height bound (92 wide, 160 tall), so a hostile slide ratio can't create a
+    // giant empty layout box before the canvas renders.
+    const ratio = Math.min(p.width > 0 ? p.height / p.width : 1.294, 160 / 92);
     t.innerHTML = `<div class="ph" style="height:${Math.round(92 * ratio)}px"></div>
       <div class="n">${p.page_number}${p.scanned ? '<span class="sc">scan</span>' : ""}</div>`;
     t.onclick = () => goto(i, state.gen);
@@ -705,7 +708,7 @@ async function renderThumb(el, gen) {
   if (gen !== state.gen) return;
   if (state.format === "pptx") {
     const pageJson = state.extraction.pages[Number(el.dataset.idx)];
-    const rendered = schematicBitmap(pageJson, 92, 1, 1);
+    const rendered = schematicBitmap(pageJson, 92, 1, 1, { minCssW: 92, maxCssH: 160 });
     if (gen !== state.gen || !rendered) return;
     const ph = el.querySelector(".ph");
     if (ph) ph.replaceWith(rendered.canvas);
@@ -1109,13 +1112,24 @@ function drawSchematicElement(ctx, pageJson, el, idx, k, roleByElement) {
   ctx.restore();
 }
 
-function schematicBitmap(pageJson, fitWidth, zoom, dpr = window.devicePixelRatio || 1) {
+function schematicBitmap(pageJson, fitWidth, zoom, dpr = window.devicePixelRatio || 1, opts = {}) {
   const pageWidth = Number(pageJson.width);
   const pageHeight = Number(pageJson.height);
   if (!Number.isFinite(pageWidth) || !Number.isFinite(pageHeight) ||
       pageWidth <= 0 || pageHeight <= 0) return null;
-  const cssW = Math.min(Math.max(fitWidth, 240), 900) * zoom;
-  const k = cssW / pageWidth;
+  const minCssW = opts.minCssW ?? 240;
+  const maxCssH = opts.maxCssH ?? Infinity;
+  let cssW = Math.min(Math.max(fitWidth, minCssW), 900) * zoom;
+  let k = cssW / pageWidth;
+  // A hostile deck can declare a pathological slide aspect ratio (e.g. 1x68).
+  // Fit to the height box instead of the width in that case — letterbox rather
+  // than allocate a giant backing store. Thumbnails pass a small maxCssH so the
+  // persistent rail canvases stay tiny; the main view is additionally charged
+  // to the byte-capped LRU by its caller.
+  if (pageHeight * k > maxCssH) {
+    k = maxCssH / pageHeight;
+    cssW = pageWidth * k;
+  }
   const cssH = pageHeight * k;
   const pixelW = Math.floor(cssW * dpr);
   const pixelH = Math.floor(cssH * dpr);

--- a/crates/docray-server/src/http.rs
+++ b/crates/docray-server/src/http.rs
@@ -63,10 +63,11 @@ async fn healthz() -> Json<serde_json::Value> {
     Json(serde_json::json!({ "status": "ok" }))
 }
 
-/// Interactive testing UI: upload a PDF, see each page beside its extracted
-/// bounding boxes, and inspect the JSON. Single self-contained file embedded
-/// at compile time; pdf.js and fonts load from CDNs, so the page (not the
-/// API) needs outbound network access in the viewer's browser.
+/// Interactive testing UI: upload a PDF or PPTX, see each rendered PDF page or
+/// extracted PPTX structure schematic beside its bounding boxes, and inspect
+/// the JSON. Single self-contained file embedded at compile time; pdf.js and
+/// fonts load from CDNs, so the page (not the API) needs outbound network
+/// access in the viewer's browser.
 async fn playground() -> Response {
     (
         StatusCode::OK,

--- a/crates/docray-wasm/Cargo.toml
+++ b/crates/docray-wasm/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 docray-core = { path = "../docray-core" }
 docray-model = { path = "../docray-model" }
 docray-pdf = { path = "../docray-pdf" }
+docray-pptx = { path = "../docray-pptx" }
 serde.workspace = true
 serde_json.workspace = true
 wasm-bindgen = "0.2"

--- a/crates/docray-wasm/src/lib.rs
+++ b/crates/docray-wasm/src/lib.rs
@@ -9,12 +9,15 @@
 //! exception. Discard both module instances and respawn the worker, mirroring
 //! docray-server's native subprocess isolation.
 
-use docray_core::{ExtractError, Extractor};
-use docray_model::{GranularExtraction, Granularity};
+use docray_core::{check_granularity, sniff_format, ExtractError, Extractor, Format};
+use docray_model::{Extraction, GranularExtraction, Granularity};
 use docray_pdf::PdfExtractor;
+use docray_pptx::PptxExtractor;
 use wasm_bindgen::prelude::*;
 
-/// Extracts a PDF entirely in WASM and returns docray JSON.
+const CFB_MAGIC: &[u8; 8] = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1";
+
+/// Extracts a PDF or PPTX entirely in WASM and returns docray JSON.
 ///
 /// `granularity` accepts "element", "word", "char", or the empty string for
 /// the frozen schema 1.1 response. `max_input_bytes` is a caller-selected byte
@@ -33,7 +36,7 @@ pub fn extract(
     extract_inner(bytes, granularity, max_input_bytes, max_output_bytes).map_err(WasmError::into_js)
 }
 
-/// Extracts a PDF and returns the token-lean line format (see the docs'
+/// Extracts a PDF or PPTX and returns the token-lean line format (see the docs'
 /// Output formats page). `granularity` accepts "element", "word", or the
 /// empty string (implies element, matching the CLI/HTTP surfaces). "char" is
 /// rejected with the stable `bad_format` error code, like everywhere else.
@@ -75,9 +78,7 @@ fn extract_lean_inner(
             ))
         }
     };
-    let extraction = PdfExtractor
-        .extract(bytes, None)
-        .map_err(WasmError::from_extract)?;
+    let extraction = extract_document(bytes, Some(granularity))?;
     match extraction.with_granularity(granularity) {
         GranularExtraction::Compact(compact) => {
             let mut w = CappedString {
@@ -110,18 +111,42 @@ fn extract_inner(
         ));
     }
 
-    let extraction = PdfExtractor
-        .extract(bytes, None)
-        .map_err(WasmError::from_extract)?;
-
-    if granularity.is_empty() {
-        json_capped(&extraction, cap)
+    let requested = if granularity.is_empty() {
+        None
     } else {
-        let granularity = granularity
-            .parse::<Granularity>()
-            .map_err(WasmError::parse_failure)?;
+        Some(
+            granularity
+                .parse::<Granularity>()
+                .map_err(WasmError::parse_failure)?,
+        )
+    };
+    let extraction = extract_document(bytes, requested)?;
+
+    if let Some(granularity) = requested {
         json_capped(&extraction.with_granularity(granularity), cap)
+    } else {
+        json_capped(&extraction, cap)
     }
+}
+
+/// Mirrors the CLI's format dispatch and, critically, performs the capability
+/// check before extraction. The PPTX arm never touches Pdfium.
+fn extract_document(bytes: &[u8], requested: Option<Granularity>) -> Result<Extraction, WasmError> {
+    let result = match sniff_format(bytes) {
+        Some(Format::Pdf) => {
+            let extractor = PdfExtractor;
+            check_granularity(&extractor.capabilities(), requested)
+                .and_then(|()| extractor.extract(bytes, None))
+        }
+        Some(Format::Zip) => {
+            let extractor = PptxExtractor;
+            check_granularity(&extractor.capabilities(), requested)
+                .and_then(|()| extractor.extract(bytes, None))
+        }
+        None if bytes.starts_with(CFB_MAGIC) => PptxExtractor.extract(bytes, None),
+        None => Err(ExtractError::UnsupportedFormat),
+    };
+    result.map_err(WasmError::from_extract)
 }
 
 #[derive(Debug, PartialEq)]
@@ -262,9 +287,41 @@ mod tests {
 
     #[test]
     fn zero_input_cap_is_uncapped() {
-        let error = extract_inner(b"not a PDF", "", 0, 0).unwrap_err();
+        let error = extract_inner(b"not a document", "", 0, 0).unwrap_err();
 
         assert_ne!(error.code, "too_large");
+    }
+
+    #[test]
+    fn pptx_element_json_extracts_without_pdfium() {
+        let bytes = include_bytes!("../../../testdata/pptx/table.pptx");
+        let json = extract_inner(bytes, "element", 0, 0).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value["schema_version"], "1.4");
+        assert_eq!(value["granularity"], "element");
+        assert_eq!(value["source"]["format"], "pptx");
+        assert_eq!(value["pages"][0]["elements"][0]["type"], "table");
+    }
+
+    #[test]
+    fn pptx_rejects_implicit_and_word_granularity() {
+        let bytes = include_bytes!("../../../testdata/pptx/table.pptx");
+        for granularity in ["", "char", "word"] {
+            let error = extract_inner(bytes, granularity, 0, 0).unwrap_err();
+            assert_eq!(error.code, "granularity_unavailable");
+        }
+    }
+
+    #[test]
+    fn cfb_magic_uses_the_cli_legacy_office_error() {
+        let error = extract_inner(CFB_MAGIC, "element", 0, 0).unwrap_err();
+
+        assert_eq!(error.code, "unsupported_format");
+        assert_eq!(
+            error.message,
+            "legacy or encrypted Office documents are not supported"
+        );
     }
 
     use std::fmt::Write as _;

--- a/scripts/wasm-parity.cjs
+++ b/scripts/wasm-parity.cjs
@@ -13,7 +13,13 @@ if (!pkgArgument || !nativeArgument) {
 const root = path.resolve(__dirname, "..");
 const pkgDir = path.resolve(pkgArgument);
 const nativeCli = path.resolve(nativeArgument);
-const fixtures = ["simple.pdf", "form.pdf", "rotated.pdf", "link.pdf"];
+const fixtures = [
+  { file: "pptx/table.pptx", granularity: "element", exact: true },
+  { file: "simple.pdf", granularity: "" },
+  { file: "form.pdf", granularity: "" },
+  { file: "rotated.pdf", granularity: "" },
+  { file: "link.pdf", granularity: "" },
+];
 
 function exact(failures, label, a, b) {
   if (JSON.stringify(a) !== JSON.stringify(b)) {
@@ -149,19 +155,37 @@ function compare(native, wasm) {
   };
 }
 
+function compareExact(native, wasm) {
+  const failures = [];
+  exact(failures, "canonical extraction", native, wasm);
+  return {
+    ok: failures.length === 0,
+    failures,
+    failure_count: failures.length,
+    geometry_comparisons: 0,
+    max_geometry_delta_pt: 0,
+    seen: {},
+  };
+}
+
 async function main() {
   for (const file of ["docray_wasm.js", "pdfium.js", "pdfium.wasm"]) {
     if (!fs.existsSync(path.join(pkgDir, file))) throw new Error(`missing ${path.join(pkgDir, file)}`);
   }
   if (!fs.existsSync(nativeCli)) throw new Error(`missing native CLI ${nativeCli}`);
 
-  const PDFiumModule = require(path.join(pkgDir, "pdfium.js"));
-  const pdfium = await PDFiumModule({
-    locateFile: (file) => file.endsWith(".wasm") ? path.join(pkgDir, "pdfium.wasm") : file,
-  });
   const docray = require(path.join(pkgDir, "docray_wasm.js"));
-  if (!docray.initialize_pdfium_render(pdfium, docray.__wasm ?? docray, false)) {
-    throw new Error("pdfium-render rejected the Emscripten Pdfium module");
+  let pdfiumInitialized = false;
+  async function ensurePdfium() {
+    if (pdfiumInitialized) return;
+    const PDFiumModule = require(path.join(pkgDir, "pdfium.js"));
+    const pdfium = await PDFiumModule({
+      locateFile: (file) => file.endsWith(".wasm") ? path.join(pkgDir, "pdfium.wasm") : file,
+    });
+    if (!docray.initialize_pdfium_render(pdfium, docray.__wasm ?? docray, false)) {
+      throw new Error("pdfium-render rejected the Emscripten Pdfium module");
+    }
+    pdfiumInitialized = true;
   }
 
   try {
@@ -176,30 +200,38 @@ async function main() {
 
   const results = [];
   for (const fixture of fixtures) {
-    const fixturePath = path.join(root, "testdata", fixture);
-    const nativeRun = spawnSync(nativeCli, ["extract", fixturePath], {
+    const { file, granularity, exact: requiresExact } = fixture;
+    const fixturePath = path.join(root, "testdata", file);
+    // Deliberately extract PPTX before Pdfium initialization. This proves the
+    // pure-Rust Office path has no hidden dependency on the Emscripten module.
+    if (file.endsWith(".pdf")) await ensurePdfium();
+    const nativeArgs = ["extract", fixturePath];
+    if (granularity) nativeArgs.push("--granularity", granularity);
+    const nativeRun = spawnSync(nativeCli, nativeArgs, {
       cwd: root,
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
     });
     if (nativeRun.status !== 0) {
-      throw new Error(`native extraction failed for ${fixture}: ${nativeRun.stderr.trim()}`);
+      throw new Error(`native extraction failed for ${file}: ${nativeRun.stderr.trim()}`);
     }
 
     const native = JSON.parse(nativeRun.stdout);
-    const wasm = JSON.parse(docray.extract(fs.readFileSync(fixturePath), "", 0, 0));
-    results.push({ fixture, ...compare(native, wasm) });
+    const wasm = JSON.parse(docray.extract(fs.readFileSync(fixturePath), granularity, 0, 0));
+    results.push({ fixture: file, ...(requiresExact ? compareExact(native, wasm) : compare(native, wasm)) });
 
     // Lean output must match wasm-vs-native: same Rust renderer over the
     // same extraction. Structure/content compare exactly; numbers within
     // the JSON comparator's 2pt tolerance (pdfium builds differ sub-point).
-    const leanNative = spawnSync(nativeCli, ["extract", fixturePath, "--format", "lean"], {
+    const leanArgs = ["extract", fixturePath, "--format", "lean"];
+    if (granularity) leanArgs.push("--granularity", granularity);
+    const leanNative = spawnSync(nativeCli, leanArgs, {
       cwd: root,
       encoding: "utf8",
       maxBuffer: 64 * 1024 * 1024,
     });
     if (leanNative.status !== 0) {
-      throw new Error(`native lean failed for ${fixture}: ${leanNative.stderr.trim()}`);
+      throw new Error(`native lean failed for ${file}: ${leanNative.stderr.trim()}`);
     }
     const leanWasm = docray.extract_lean(fs.readFileSync(fixturePath), "element", 0, 0);
     const leanLines = { native: leanNative.stdout.split("\n").length, wasm: leanWasm.split("\n").length };
@@ -210,7 +242,7 @@ async function main() {
       if (!leanLineClose(nNorm[i], wNorm[i])) { firstDiff = i; break; }
     }
     const leanOk = firstDiff === -1;
-    results.push({ fixture: fixture + " (lean)", ok: leanOk, failures: leanOk ? [] : [
+    results.push({ fixture: file + " (lean)", ok: leanOk, failures: leanOk ? [] : [
       `lean differs at line ${firstDiff}: native=${JSON.stringify(nNorm[firstDiff])} wasm=${JSON.stringify(wNorm[firstDiff])}`,
     ], failure_count: leanOk ? 0 : 1 });
   }

--- a/web/worker.js
+++ b/web/worker.js
@@ -15,33 +15,54 @@
  *
  * Classic worker on purpose: pdfium.js is UMD (importScripts-compatible),
  * docray_wasm.js is an ES module (loaded via dynamic import, which classic
- * workers support).
+ * workers support). Pdfium is loaded lazily only after PDF magic is seen;
+ * PPTX extraction is pure Rust and never touches the Emscripten module.
  */
 "use strict";
 
-importScripts("wasm/pdfium.js"); // exposes global PDFiumModule (UMD)
+let wasmInitPromise = null;
+let pdfiumInitPromise = null;
 
-let initPromise = null;
-
-function initOnce() {
-  if (!initPromise) {
-    initPromise = (async () => {
-      const pdfium = await PDFiumModule({
-        locateFile: f => (f.endsWith(".wasm") ? "wasm/pdfium.wasm" : f),
-      });
+function initWasm() {
+  if (!wasmInitPromise) {
+    wasmInitPromise = (async () => {
       const docray = await import("./wasm/docray_wasm.js");
       const wasm = await docray.default({ module_or_path: "wasm/docray_wasm_bg.wasm" });
-      if (!docray.initialize_pdfium_render(pdfium, wasm, false)) {
-        throw new Error("pdfium-render rejected the pdfium module");
-      }
-      return docray;
+      return { docray, wasm };
     })();
-    initPromise.then(
+    wasmInitPromise.then(
       () => postMessage({ cmd: "ready" }),
       () => {}, // failures surface per-request below
     );
   }
-  return initPromise;
+  return wasmInitPromise;
+}
+
+function initPdfium(docray, wasm) {
+  if (!pdfiumInitPromise) {
+    pdfiumInitPromise = (async () => {
+      importScripts("wasm/pdfium.js"); // exposes global PDFiumModule (UMD)
+      const pdfium = await PDFiumModule({
+        locateFile: f => (f.endsWith(".wasm") ? "wasm/pdfium.wasm" : f),
+      });
+      if (!docray.initialize_pdfium_render(pdfium, wasm, false)) {
+        throw new Error("pdfium-render rejected the pdfium module");
+      }
+      return pdfium;
+    })();
+  }
+  return pdfiumInitPromise;
+}
+
+function sniffFormat(bytes) {
+  if (bytes.length >= 4 && bytes[0] === 0x50 && bytes[1] === 0x4b &&
+      bytes[2] === 0x03 && bytes[3] === 0x04) return "pptx";
+  const end = Math.min(bytes.length - 5, 1023);
+  for (let i = 0; i <= end; i += 1) {
+    if (bytes[i] === 0x25 && bytes[i + 1] === 0x50 && bytes[i + 2] === 0x44 &&
+        bytes[i + 3] === 0x46 && bytes[i + 4] === 0x2d) return "pdf";
+  }
+  return "other";
 }
 
 function errorEnvelope(e) {
@@ -64,14 +85,16 @@ self.onmessage = async ev => {
   const { id, cmd, bytes, granularity, cap } = ev.data;
   if (cmd !== "extract" && cmd !== "extract_lean") return;
   try {
-    const docray = await initOnce();
+    const input = new Uint8Array(bytes);
+    const { docray, wasm } = await initWasm();
+    if (sniffFormat(input) === "pdf") await initPdfium(docray, wasm);
     const t0 = performance.now();
     // Output budget enforced INSIDE the wasm during serialization (a
     // pathological PDF can't OOM the worker by materializing a huge string);
     // the post-hoc units check below stays as a second belt.
     const json = cmd === "extract_lean"
-      ? docray.extract_lean(new Uint8Array(bytes), granularity || "", cap || 0, OUTPUT_CAP_UNITS * 2)
-      : docray.extract(new Uint8Array(bytes), granularity || "", cap || 0, OUTPUT_CAP_UNITS * 2);
+      ? docray.extract_lean(input, granularity || "", cap || 0, OUTPUT_CAP_UNITS * 2)
+      : docray.extract(input, granularity || "", cap || 0, OUTPUT_CAP_UNITS * 2);
     if (json.length > OUTPUT_CAP_UNITS) {
       postMessage({ id, ok: false, error: { code: "output_too_large",
         message: "extraction produced " + json.length + " code units (cap " + OUTPUT_CAP_UNITS + ")" } });
@@ -83,4 +106,4 @@ self.onmessage = async ev => {
   }
 };
 
-initOnce(); // warm eagerly: module fetch+compile overlaps with the user picking a file
+initWasm(); // warm Rust eagerly; Pdfium waits until a PDF request actually needs it


### PR DESCRIPTION
## What
Completes browser support for PPTX: it extracts entirely in-WASM through the canonical `PptxExtractor` and renders as an explicitly-labeled structure schematic.

- **docray-wasm** sniffs format and mirrors CLI dispatch/capability checks: PDF → `PdfExtractor`, ZIP → `PptxExtractor`, CFB → the stable legacy/encrypted-Office error. PPTX implicit/char/word → `granularity_unavailable`; element JSON and lean use the same renderers as CLI/server.
- **Pdfium loads lazily** — only when PDF magic is seen — so PPTX never fetches or requires the Emscripten module.
- **Playground** accepts PDF/PPTX (sniffs `PK\x03\x04`). PPTX source/boxes/x-ray render a slide-sized schematic (bbox strokes, clipped text, image/path placeholders, role labels, table grids/cells) with a persistent caption stating it is reconstructed from extraction, **not a visual render**. Tables and per-run styles surface in the boxes/text/JSON/LLM lenses.
- **Security:** every document-controlled string reaches the DOM only via `escapeHtml`/`textContent`; schematic text uses canvas `fillText`; no document href is installed into a DOM link. pdf.js stays 4.10.38 with `isEvalSupported:false`. Thumbnail canvas memory is bounded (fit-to-box height cap) so a hostile slide aspect ratio can't defeat the byte cap.
- **Parity:** `scripts/wasm-parity.cjs` adds `pptx/table.pptx` (JSON + lean), matching native CLI vs WASM exactly — enforcing the canonical/identical promise for PPTX.

## WASM size
Optimized module 741 KB → 1015 KB (+37%) from adding the pure-Rust PPTX path (zip uses `flate2/rust_backend`/miniz_oxide; no zlib-sys).

## Docs
try/demo copy and docs describe PDF or PPTX and distinguish the PPTX schematic from a faithful render; no PDF token figures reused for PPTX.

## Checks
fmt / clippy -D warnings / `cargo test --workspace` green; `build-wasm.sh` (web + nodejs) succeeds; parity passes incl. PPTX; both gen_fixtures deterministic; testdata diff empty. Adversarial security review clean on XSS/href/lifecycle; the one finding (thumbnail memory) is fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)