### PR TITLE
Fix: PPTX source schematic no longer draws bounding boxes

### DIFF
--- a/crates/docray-server/assets/playground.html
+++ b/crates/docray-server/assets/playground.html
@@ -1005,11 +1005,6 @@ function cachePut(key, entry) {
   }
 }
 
-const SCHEMATIC_COLORS = {
-  text: "#1376a8", image: "#b32674", path: "#3d7d24",
-  annotation: "#9a6a00", table: "#7650a8",
-};
-
 function validSchematicBBox(value) {
   const b = normBBox(value);
   if (!b) return null;
@@ -1059,24 +1054,26 @@ function schematicText(ctx, value, bbox, k, font) {
   ctx.restore();
 }
 
+// Draws one element as CONTENT ONLY — the reconstructed appearance of the
+// slide. The colored per-element bounding boxes belong to the BOXES / X-RAY
+// lenses (drawn as an SVG overlay on top of this canvas), so the SOURCE view
+// must not stroke them here.
 function drawSchematicElement(ctx, pageJson, el, idx, k, roleByElement) {
   const bbox = validSchematicBBox(el.bbox);
   if (!bbox) return;
-  const color = SCHEMATIC_COLORS[el.type] || "#6f675b";
   const x = bbox.x0 * k;
   const y = bbox.y0 * k;
   const width = Math.max((bbox.x1 - bbox.x0) * k, 0.5);
   const height = Math.max((bbox.y1 - bbox.y0) * k, 0.5);
   ctx.save();
-  ctx.strokeStyle = color;
-  ctx.lineWidth = 1;
-  ctx.strokeRect(x, y, width, height);
-  ctx.fillStyle = color + "12";
-  ctx.fillRect(x, y, width, height);
 
   if (el.type === "text") {
     schematicText(ctx, elementText(el), bbox, k, el.font);
   } else if (el.type === "table") {
+    // Gridlines are part of a table's actual appearance (content), not an
+    // analysis overlay — draw them in a neutral ink, like a real table.
+    ctx.strokeStyle = "rgba(22,19,15,0.30)";
+    ctx.lineWidth = 1;
     for (const cell of el.cells || []) {
       const cb = validSchematicBBox(cell.bbox);
       if (!cb) continue;
@@ -1087,14 +1084,25 @@ function drawSchematicElement(ctx, pageJson, el, idx, k, roleByElement) {
       );
       schematicText(ctx, cell.content, cb, k, cell.runs && cell.runs[0] && cell.runs[0].font);
     }
-  } else {
-    const label = el.type === "annotation" && el.subtype ? el.subtype : el.type;
-    ctx.fillStyle = color;
+  } else if (el.type === "image") {
+    // A picture region we cannot render: neutral placeholder, not a colored box.
+    ctx.fillStyle = "rgba(22,19,15,0.06)";
+    ctx.fillRect(x, y, width, height);
+    ctx.strokeStyle = "rgba(22,19,15,0.16)";
+    ctx.lineWidth = 1;
+    ctx.strokeRect(x, y, width, height);
+    ctx.fillStyle = "rgba(22,19,15,0.42)";
     ctx.font = '600 10px "IBM Plex Mono", monospace';
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
-    ctx.fillText(String(label || "element").toUpperCase(), x + width / 2, y + height / 2, Math.max(width - 8, 1));
+    ctx.fillText("IMAGE", x + width / 2, y + height / 2, Math.max(width - 8, 1));
+  } else if (el.type === "path") {
+    // A vector shape: subtle neutral fill so its area reads on the slide.
+    ctx.fillStyle = "rgba(22,19,15,0.05)";
+    ctx.fillRect(x, y, width, height);
   }
+  // Annotations (e.g. hyperlinks) are not visible slide content — they surface
+  // only in the BOXES / X-RAY overlay, TEXT, JSON, and LLM lenses.
 
   const id = el.id || `p${pageJson.page_number}-e${idx}`;
   const role = roleByElement.get(id);


### PR DESCRIPTION
The playground SOURCE lens for PPTX was showing colored per-element bounding boxes, making it nearly identical to the BOXES lens (and double-boxing BOXES/X-RAY).

**Cause:** the schematic canvas is the shared base for source/boxes/x-ray, and boxes/x-ray add a colored SVG overlay on top (only when `mode !== "source"`). But the base `drawSchematicElement` was *also* stroking a colored box + faint fill around every element, so the boxes leaked into SOURCE and were drawn twice in BOXES/X-RAY.

**Fix:** the base schematic now renders content only —
- text → text
- table → neutral gridlines + cell text (a table's actual appearance)
- image → neutral placeholder (not a colored box)
- path → subtle neutral fill
- annotation → nothing (not visible slide content)

Colored element boxes now come solely from the boxes/x-ray SVG overlay. Verified the attached-style real deck extracts (schema 1.4, text + table) and the JS parses / server builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)