### PR TITLE
PPTX rail thumbnails show the rendered SOURCE (sandboxed)

### DIFF
--- a/book/src/playground.md
+++ b/book/src/playground.md
@@ -14,7 +14,8 @@ way to understand what docray extracts and to debug a specific document.
 Drop a PDF or PPTX on it and every page or slide appears with:
 
 - **A thumbnail rail** for navigation (arrow keys work; scanned pages carry a
-  badge).
+  badge). PPTX thumbnails render progressively as they scroll into view and
+  fall back individually to the extraction schematic if visual rendering fails.
 - **Two independent panels**, each switchable between six lenses:
   - **source** — the rendered PDF page, or an offline visual PPTX render inside
     a locked-down, null-origin browser sandbox
@@ -45,8 +46,9 @@ Hover any box for its content, font, and coordinates.
 - Hostile PPTX visual rendering runs in an iframe with only
   `sandbox="allow-scripts"` and a `default-src 'none'` Content Security Policy.
   The parent transfers document bytes in, never reads the iframe DOM, and
-  accepts only a small status message back. Errors and timeouts fall back to
-  the structure schematic built from docray's extraction.
+  accepts only small status messages plus a size-bounded PNG/WebP data URL for
+  each thumbnail; that inert URL is used only as an image source. Errors and
+  timeouts fall back to the structure schematic built from docray's extraction.
 - Uploads go to the server's own `/v1/extract`; nothing leaves your
   deployment.
 - The UI is a single self-contained HTML file compiled into the server

--- a/crates/docray-server/assets/playground.html
+++ b/crates/docray-server/assets/playground.html
@@ -122,14 +122,15 @@
     padding: 12px 0 40px;
   }
   .thumb { padding: 6px 14px; cursor: pointer; text-align: center; }
-  .thumb canvas, .thumb .ph {
+  .thumb canvas, .thumb img, .thumb .ph {
     width: 92px; display: block; margin: 0 auto;
     background: var(--film); box-shadow: 0 0 0 1px var(--hair);
     opacity: 0.75; transition: opacity 0.15s, box-shadow 0.15s;
   }
+  .thumb img { height: auto; }
   .thumb .ph { background: var(--ink-3); }
   .thumb .n { font-size: 9.5px; color: var(--fg-dim); margin-top: 4px; }
-  .thumb.cur canvas, .thumb.cur .ph { opacity: 1; box-shadow: 0 0 0 2px var(--amber); }
+  .thumb.cur canvas, .thumb.cur img, .thumb.cur .ph { opacity: 1; box-shadow: 0 0 0 2px var(--amber); }
   .thumb.cur .n { color: var(--amber); }
   .thumb .sc { display: inline-block; font-size: 8px; letter-spacing: 0.1em; color: #241a08; background: var(--c-annotation); padding: 0 4px; border-radius: 2px; margin-left: 4px; }
 
@@ -273,7 +274,7 @@
     #panels { grid-template-columns: 1fr; }
     .panel + .panel { border-left: 0; border-top: 1px dashed var(--hair); }
     #rail { width: 84px; }
-    .thumb canvas, .thumb .ph { width: 60px; }
+    .thumb canvas, .thumb img, .thumb .ph { width: 60px; }
   }
 </style>
 </head>
@@ -41327,6 +41328,7 @@ const state = {
   filters: new Set(TYPES),
   panelModes: ["source", "boxes"],
   renderCache: new Map(), // "pageNo@zoom@fit" -> {canvas, cssW, cssH, k}
+  pptxThumbCache: new Map(), // slide index -> {dataUrl, bytes}; insertion order is LRU
 };
 
 /* ── status ── */
@@ -41380,6 +41382,10 @@ const BROWSER_OUTPUT_NOTE = "output_too_large"; // enforced inside worker.js
 const BROWSER_TIMEOUT_MS = 120_000;
 const PPTX_RENDER_TIMEOUT_MS = 15_000;
 const PPTX_CANVAS_BYTE_CAP = 256 * 1024 * 1024;
+const PPTX_THUMB_TIMEOUT_MS = 15_000;
+const PPTX_THUMB_TARGET_WIDTH = 240;
+const PPTX_THUMB_DATA_URL_MAX = 3 * 1024 * 1024;
+const PPTX_THUMB_BYTE_CAP = 256 * 1024 * 1024;
 const PPTX_IFRAME_SANDBOX = "allow-scripts";
 // base-uri and form-action do NOT fall back to default-src, so pin them
 // explicitly (belt-and-suspenders with the forms-less sandbox) to close a
@@ -41616,8 +41622,11 @@ async function load(file, keepPageIdx) {
 
   // Success: replace the old document wholesale.
   if (state.pdf) state.pdf.destroy();
+  resetPptxThumbRenderer();
   state.renderCache.clear();
   cacheBytes = 0;
+  state.pptxThumbCache.clear();
+  pptxThumbCacheBytes = 0;
   state.file = file;
   state.fileName = file.name;
   state.extraction = extraction;
@@ -41669,6 +41678,9 @@ function restoreRetainedDocument(gen) {
 
 /* ── thumbnail rail (lazy) ── */
 let railObserver = null;
+let pptxThumbRenderer = null;
+let pptxThumbCacheBytes = 0;
+let pptxThumbInitFailedGen = -1;
 
 function buildRail(gen) {
   const rail = $("#rail");
@@ -41701,11 +41713,7 @@ function buildRail(gen) {
 async function renderThumb(el, gen) {
   if (gen !== state.gen) return;
   if (state.format === "pptx") {
-    const pageJson = state.extraction.pages[Number(el.dataset.idx)];
-    const rendered = schematicBitmap(pageJson, 92, 1, 1, { minCssW: 92, maxCssH: 160 });
-    if (gen !== state.gen || !rendered) return;
-    const ph = el.querySelector(".ph");
-    if (ph) ph.replaceWith(rendered.canvas);
+    renderPptxThumb(el, Number(el.dataset.idx), gen);
     return;
   }
   if (!state.pdf) return;
@@ -41727,6 +41735,273 @@ async function renderThumb(el, gen) {
     const ph = el.querySelector(".ph");
     if (ph) ph.replaceWith(canvas);
   } catch (_) { /* thumbnail failure is cosmetic */ }
+}
+
+function mountPptxSchematicThumb(el, index, gen) {
+  if (gen !== state.gen || !el.isConnected) return;
+  const pageJson = state.extraction.pages[index];
+  const rendered = schematicBitmap(pageJson, 92, 1, 1, { minCssW: 92, maxCssH: 160 });
+  if (!rendered) return;
+  rendered.canvas.dataset.thumbKind = "schematic";
+  const old = el.querySelector("img, canvas, .ph");
+  if (old) old.replaceWith(rendered.canvas);
+}
+
+function validPptxThumbDataUrl(value) {
+  return typeof value === "string" && value.length <= PPTX_THUMB_DATA_URL_MAX &&
+    (value.startsWith("data:image/png;base64,") ||
+     value.startsWith("data:image/webp;base64,"));
+}
+
+function pptxThumbCacheGet(index) {
+  const hit = state.pptxThumbCache.get(index);
+  if (!hit) return null;
+  state.pptxThumbCache.delete(index);
+  state.pptxThumbCache.set(index, hit);
+  return hit;
+}
+
+function pptxThumbCacheDelete(index) {
+  const entry = state.pptxThumbCache.get(index);
+  if (!entry) return;
+  pptxThumbCacheBytes -= entry.bytes;
+  state.pptxThumbCache.delete(index);
+}
+
+function pptxThumbCachePut(index, dataUrl, decodedBytes, gen) {
+  pptxThumbCacheDelete(index);
+  // Account for both decoded pixels and the retained base64 string. Browsers
+  // vary in when decoded image memory is released, so the larger estimate is
+  // the conservative cache charge.
+  const encodedBytes = Math.ceil(dataUrl.length * 3 / 4);
+  const entry = { dataUrl, bytes: Math.max(decodedBytes, encodedBytes) };
+  if (entry.bytes > PPTX_THUMB_BYTE_CAP) return false;
+  state.pptxThumbCache.set(index, entry);
+  pptxThumbCacheBytes += entry.bytes;
+  for (const [evictedIndex, evicted] of state.pptxThumbCache) {
+    if (pptxThumbCacheBytes <= PPTX_THUMB_BYTE_CAP) break;
+    state.pptxThumbCache.delete(evictedIndex);
+    pptxThumbCacheBytes -= evicted.bytes;
+    const mounted = document.querySelector(`.thumb[data-idx="${evictedIndex}"] img[data-thumb-kind="rendered"]`);
+    if (mounted) mountPptxSchematicThumb(mounted.closest(".thumb"), evictedIndex, gen);
+  }
+  return state.pptxThumbCache.has(index);
+}
+
+function mountPptxThumbImage(el, index, dataUrl, gen) {
+  const image = new Image();
+  image.alt = `Rendered slide ${index + 1} thumbnail`;
+  image.decoding = "async";
+  image.dataset.thumbKind = "rendered";
+  image.onload = () => {
+    if (gen !== state.gen || !el.isConnected) return;
+    const cached = state.pptxThumbCache.get(index);
+    if (!cached || cached.dataUrl !== dataUrl) {
+      mountPptxSchematicThumb(el, index, gen);
+      return;
+    }
+    const old = el.querySelector("img, canvas, .ph");
+    if (old) old.replaceWith(image);
+  };
+  image.onerror = () => {
+    pptxThumbCacheDelete(index);
+    mountPptxSchematicThumb(el, index, gen);
+  };
+  // The validated inert image URL is used only as an img src. It is never
+  // parsed as markup or inserted through innerHTML.
+  image.src = dataUrl;
+}
+
+function pptxThumbDimensions(pageJson) {
+  const width = Number(pageJson.width);
+  const height = Number(pageJson.height);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  const maxHeight = Math.ceil(PPTX_THUMB_TARGET_WIDTH * 160 / 92);
+  return {
+    width: PPTX_THUMB_TARGET_WIDTH,
+    height: Math.max(1, Math.min(Math.ceil(PPTX_THUMB_TARGET_WIDTH * height / width), maxHeight)),
+  };
+}
+
+function renderPptxThumb(el, index, gen) {
+  const pageJson = state.extraction.pages[index];
+  const dimensions = pptxThumbDimensions(pageJson);
+  const pageParseFailed = (state.extraction.warnings || []).some(warning =>
+    typeof warning === "string" && warning.startsWith(`page ${index + 1} failed to parse:`));
+  if (!dimensions || state.file.size > BROWSER_INPUT_CAP || pageParseFailed ||
+      pptxThumbInitFailedGen === gen) {
+    mountPptxSchematicThumb(el, index, gen);
+    return;
+  }
+  const cached = pptxThumbCacheGet(index);
+  if (cached) {
+    mountPptxThumbImage(el, index, cached.dataUrl, gen);
+    return;
+  }
+  const renderer = ensurePptxThumbRenderer(gen);
+  if (!renderer) {
+    mountPptxSchematicThumb(el, index, gen);
+    return;
+  }
+  renderer.queue.push({ el, index, gen, dimensions });
+  pumpPptxThumbQueue(renderer);
+}
+
+function closePptxThumbRenderer(renderer) {
+  if (!renderer || renderer.closed) return;
+  renderer.closed = true;
+  clearTimeout(renderer.readyTimer);
+  if (renderer.active) clearTimeout(renderer.active.timer);
+  removeEventListener("message", renderer.onMessage);
+  renderer.iframe.onerror = null;
+  renderer.iframe.remove();
+  if (pptxThumbRenderer === renderer) pptxThumbRenderer = null;
+}
+
+function resetPptxThumbRenderer() {
+  closePptxThumbRenderer(pptxThumbRenderer);
+  pptxThumbInitFailedGen = -1;
+}
+
+function failPptxThumbRenderer(renderer, initFailed) {
+  if (renderer.closed) return;
+  const pending = renderer.active ? [renderer.active.request, ...renderer.queue] : renderer.queue.slice();
+  renderer.queue.length = 0;
+  closePptxThumbRenderer(renderer);
+  if (initFailed) pptxThumbInitFailedGen = renderer.gen;
+  for (const request of pending) {
+    if (request.gen === state.gen) mountPptxSchematicThumb(request.el, request.index, request.gen);
+  }
+}
+
+function finishPptxThumb(renderer, ok, dataUrl, fatalInit) {
+  const active = renderer.active;
+  if (!active || renderer.closed) return;
+  clearTimeout(active.timer);
+  renderer.active = null;
+  const { request } = active;
+  if (fatalInit) {
+    if (request.gen === state.gen) mountPptxSchematicThumb(request.el, request.index, request.gen);
+    failPptxThumbRenderer(renderer, true);
+    return;
+  }
+  if (ok && request.gen === state.gen) {
+    const decodedBytes = request.dimensions.width * request.dimensions.height * 4;
+    if (pptxThumbCachePut(request.index, dataUrl, decodedBytes, request.gen)) {
+      mountPptxThumbImage(request.el, request.index, dataUrl, request.gen);
+    } else {
+      mountPptxSchematicThumb(request.el, request.index, request.gen);
+    }
+  } else if (request.gen === state.gen) {
+    mountPptxSchematicThumb(request.el, request.index, request.gen);
+  }
+  pumpPptxThumbQueue(renderer);
+}
+
+function ensurePptxThumbRenderer(gen) {
+  if (pptxThumbInitFailedGen === gen) return null;
+  if (pptxThumbRenderer && pptxThumbRenderer.gen === gen && !pptxThumbRenderer.closed) {
+    return pptxThumbRenderer;
+  }
+  closePptxThumbRenderer(pptxThumbRenderer);
+  const iframe = document.createElement("iframe");
+  iframe.title = "Sandboxed PowerPoint thumbnail renderer";
+  iframe.setAttribute("sandbox", PPTX_IFRAME_SANDBOX);
+  iframe.setAttribute("referrerpolicy", "no-referrer");
+  iframe.setAttribute("aria-hidden", "true");
+  iframe.style.cssText = "position:fixed;left:-10000px;top:0;width:240px;height:418px;" +
+    "border:0;opacity:0;pointer-events:none";
+
+  const renderer = {
+    iframe, gen, queue: [], active: null, ready: false, initialized: false,
+    bytesPosted: false, closed: false, readyTimer: null, onMessage: null,
+  };
+  renderer.onMessage = event => {
+    if (event.source !== iframe.contentWindow || event.origin !== "null" || renderer.closed) return;
+    const data = event.data;
+    if (!data || typeof data !== "object" || Array.isArray(data)) return;
+    const keys = Object.keys(data);
+    if (data.status === "ready") {
+      if (keys.length !== 1 || keys[0] !== "status" || renderer.ready) return;
+      renderer.ready = true;
+      clearTimeout(renderer.readyTimer);
+      pumpPptxThumbQueue(renderer);
+      return;
+    }
+    const active = renderer.active;
+    if (!active || !Number.isInteger(data.index) || data.index !== active.request.index) return;
+    if (data.status === "thumb") {
+      if (keys.length !== 3 || !keys.includes("status") || !keys.includes("index") ||
+          !keys.includes("dataUrl") || !validPptxThumbDataUrl(data.dataUrl)) {
+        finishPptxThumb(renderer, false);
+        return;
+      }
+      renderer.initialized = true;
+      finishPptxThumb(renderer, true, data.dataUrl, false);
+    } else if (data.status === "error") {
+      if (keys.some(key => key !== "status" && key !== "index" && key !== "message") ||
+          (data.message !== undefined &&
+            (typeof data.message !== "string" || data.message.length > 160))) return;
+      const fatalInit = !renderer.initialized && data.message === "init";
+      if (!fatalInit) renderer.initialized = true;
+      finishPptxThumb(renderer, false, undefined, fatalInit);
+    }
+  };
+  addEventListener("message", renderer.onMessage);
+  iframe.onerror = () => failPptxThumbRenderer(renderer, true);
+  renderer.readyTimer = setTimeout(() => failPptxThumbRenderer(renderer, true), PPTX_THUMB_TIMEOUT_MS);
+  document.body.appendChild(iframe);
+  iframe.srcdoc = pptxThumbRendererSrcdoc();
+  pptxThumbRenderer = renderer;
+  return renderer;
+}
+
+async function pumpPptxThumbQueue(renderer) {
+  if (renderer.closed || !renderer.ready || renderer.active) return;
+  let request;
+  while ((request = renderer.queue.shift())) {
+    if (request.gen === state.gen && request.el.isConnected) break;
+    request = null;
+  }
+  if (!request) return;
+  const active = { request, timer: null };
+  renderer.active = active;
+  active.timer = setTimeout(() => {
+    if (renderer.active !== active) return;
+    renderer.active = null;
+    mountPptxSchematicThumb(request.el, request.index, request.gen);
+    const queued = renderer.queue.splice(0);
+    closePptxThumbRenderer(renderer);
+    for (const next of queued) {
+      if (next.gen === state.gen) renderPptxThumb(next.el, next.index, next.gen);
+    }
+  }, PPTX_THUMB_TIMEOUT_MS);
+
+  const message = {
+    cmd: "renderThumb",
+    slideIndex: request.index,
+    width: request.dimensions.width,
+    height: request.dimensions.height,
+  };
+  try {
+    if (!renderer.bytesPosted) {
+      const bytes = await state.file.arrayBuffer();
+      if (renderer.closed || renderer.active !== active || request.gen !== state.gen) return;
+      renderer.bytesPosted = true;
+      message.bytes = bytes;
+      iframePostPptxThumb(renderer.iframe, message, bytes);
+    } else {
+      renderer.iframe.contentWindow.postMessage(message, "*");
+    }
+  } catch (_) {
+    finishPptxThumb(renderer, false, undefined, !renderer.initialized);
+  }
+}
+
+function iframePostPptxThumb(iframe, message, bytes) {
+  iframe.contentWindow.postMessage(message, "*", [bytes]);
 }
 
 /* ── filter chips ── */
@@ -41911,6 +42186,233 @@ function pptxIframeMain() {
   reply("ready");
 }
 
+/* Dedicated parse-once thumbnail worker. Like pptxIframeMain, this function is
+   stringified into a null-origin srcdoc and has no access to parent helpers. */
+function pptxThumbIframeMain() {
+  "use strict";
+
+  const MAX_CANVAS_BYTES = 256 * 1024 * 1024;
+  const MAX_CANVAS_DIMENSION = 16384;
+  const MAX_DATA_URL_LENGTH = 3 * 1024 * 1024;
+  const MAX_SVG_BYTES = 16 * 1024 * 1024;
+  let viewer = null;
+  let active = false;
+
+  function reply(data) {
+    parent.postMessage(data, "*");
+  }
+
+  // The thumbnail iframe has exactly the same opaque-origin requirement as
+  // the large SOURCE iframe. Refuse hostile bytes if containment is weakened.
+  let parentAccessDenied = false;
+  try { void parent.location.href; } catch (_) { parentAccessDenied = true; }
+  if (!parentAccessDenied) {
+    reply({ status: "error", index: -1, message: "init" });
+    return;
+  }
+
+  const canvasProto = HTMLCanvasElement.prototype;
+  const widthDescriptor = Object.getOwnPropertyDescriptor(canvasProto, "width");
+  const heightDescriptor = Object.getOwnPropertyDescriptor(canvasProto, "height");
+  const originalGetContext = canvasProto.getContext;
+  const canvasAllocations = new WeakMap();
+  let canvasBytes = 0;
+
+  function canvasDimension(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? Math.max(0, Math.trunc(number)) : 0;
+  }
+
+  function chargeCanvas(canvas, width, height) {
+    const w = canvasDimension(width);
+    const h = canvasDimension(height);
+    if (w > MAX_CANVAS_DIMENSION || h > MAX_CANVAS_DIMENSION) {
+      throw new RangeError("canvas dimension cap exceeded");
+    }
+    const next = w * h * 4;
+    const previous = canvasAllocations.get(canvas) || 0;
+    if (!Number.isSafeInteger(next) || next > MAX_CANVAS_BYTES ||
+        canvasBytes - previous + next > MAX_CANVAS_BYTES) {
+      throw new RangeError("canvas memory cap exceeded");
+    }
+    canvasBytes = canvasBytes - previous + next;
+    canvasAllocations.set(canvas, next);
+  }
+
+  Object.defineProperty(canvasProto, "width", {
+    configurable: widthDescriptor.configurable,
+    enumerable: widthDescriptor.enumerable,
+    get: widthDescriptor.get,
+    set(value) {
+      chargeCanvas(this, value, heightDescriptor.get.call(this));
+      widthDescriptor.set.call(this, value);
+    },
+  });
+  Object.defineProperty(canvasProto, "height", {
+    configurable: heightDescriptor.configurable,
+    enumerable: heightDescriptor.enumerable,
+    get: heightDescriptor.get,
+    set(value) {
+      chargeCanvas(this, widthDescriptor.get.call(this), value);
+      heightDescriptor.set.call(this, value);
+    },
+  });
+  canvasProto.getContext = function(...args) {
+    chargeCanvas(this, widthDescriptor.get.call(this), heightDescriptor.get.call(this));
+    return originalGetContext.apply(this, args);
+  };
+
+  const exportCanvas = document.createElement("canvas");
+
+  function stylesheetText() {
+    let text = "";
+    for (const sheet of document.styleSheets) {
+      try {
+        for (const rule of sheet.cssRules) text += rule.cssText + "\n";
+      } catch (_) { /* all srcdoc styles are local; ignore unavailable sheets */ }
+    }
+    return text;
+  }
+
+  async function rasterize(element) {
+    await Promise.all(Array.from(element.querySelectorAll("img")).map(image => {
+      if (image.complete) return image.decode ? image.decode().catch(() => {}) : Promise.resolve();
+      return new Promise(resolve => {
+        image.addEventListener("load", resolve, { once: true });
+        image.addEventListener("error", resolve, { once: true });
+      });
+    }));
+    if (document.fonts && document.fonts.ready) await document.fonts.ready;
+    // requestAnimationFrame may be throttled indefinitely for an intentionally
+    // offscreen iframe. A task turn is enough for media/style completion while
+    // preserving progress under background-tab throttling.
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const rect = element.getBoundingClientRect();
+    const width = Math.max(1, Math.ceil(rect.width));
+    const height = Math.max(1, Math.ceil(rect.height));
+    if (width > MAX_CANVAS_DIMENSION || height > MAX_CANVAS_DIMENSION ||
+        width * height * 4 > MAX_CANVAS_BYTES) throw new Error("thumbnail dimensions unavailable");
+
+    const clone = element.cloneNode(true);
+    const originalCanvases = element.querySelectorAll("canvas");
+    const clonedCanvases = clone.querySelectorAll("canvas");
+    for (let i = 0; i < originalCanvases.length; i += 1) {
+      const replacement = document.createElement("img");
+      replacement.src = originalCanvases[i].toDataURL("image/png");
+      replacement.setAttribute("style", clonedCanvases[i].getAttribute("style") || "");
+      replacement.width = originalCanvases[i].width;
+      replacement.height = originalCanvases[i].height;
+      clonedCanvases[i].replaceWith(replacement);
+    }
+
+    const svgNs = "http://www.w3.org/2000/svg";
+    const xhtmlNs = "http://www.w3.org/1999/xhtml";
+    const svg = document.createElementNS(svgNs, "svg");
+    svg.setAttribute("width", String(width));
+    svg.setAttribute("height", String(height));
+    svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+    const foreignObject = document.createElementNS(svgNs, "foreignObject");
+    foreignObject.setAttribute("width", "100%");
+    foreignObject.setAttribute("height", "100%");
+    const wrapper = document.createElementNS(xhtmlNs, "div");
+    wrapper.setAttribute("style", `width:${width}px;height:${height}px;overflow:hidden;background:#f2eee5`);
+    const style = document.createElementNS(xhtmlNs, "style");
+    style.textContent = stylesheetText();
+    wrapper.append(style, clone);
+    foreignObject.appendChild(wrapper);
+    svg.appendChild(foreignObject);
+
+    // A blob: SVG taints a canvas in an opaque-origin sandbox. A data: SVG is
+    // still CSP-contained and inert, but remains origin-clean for canvas export.
+    const svgBytes = new TextEncoder().encode(new XMLSerializer().serializeToString(svg));
+    if (svgBytes.byteLength > MAX_SVG_BYTES) throw new Error("thumbnail SVG cap exceeded");
+    let binary = "";
+    for (let offset = 0; offset < svgBytes.length; offset += 32_768) {
+      binary += String.fromCharCode(...svgBytes.subarray(offset, offset + 32_768));
+    }
+    const url = "data:image/svg+xml;base64," + btoa(binary);
+    const image = new Image();
+    await new Promise((resolve, reject) => {
+      image.onload = resolve;
+      image.onerror = reject;
+      image.src = url;
+    });
+    exportCanvas.width = width;
+    exportCanvas.height = height;
+    const context = exportCanvas.getContext("2d");
+    context.clearRect(0, 0, width, height);
+    context.drawImage(image, 0, 0, width, height);
+    const dataUrl = exportCanvas.toDataURL("image/webp", 0.82);
+    if (dataUrl.length > MAX_DATA_URL_LENGTH ||
+        (!dataUrl.startsWith("data:image/png;base64,") &&
+         !dataUrl.startsWith("data:image/webp;base64,"))) {
+      throw new Error("thumbnail output cap exceeded");
+    }
+    return dataUrl;
+  }
+
+  addEventListener("error", () => {
+    if (active) active = false;
+  });
+  addEventListener("unhandledrejection", () => {
+    if (active) active = false;
+  });
+  addEventListener("message", async event => {
+    if (event.source !== parent || active) return;
+    const data = event.data;
+    if (!data || typeof data !== "object" || Array.isArray(data)) return;
+    const keys = Object.keys(data);
+    if (keys.some(key => !["cmd", "bytes", "slideIndex", "width", "height"].includes(key)) ||
+        data.cmd !== "renderThumb" || !Number.isInteger(data.slideIndex) || data.slideIndex < 0 ||
+        !Number.isInteger(data.width) || data.width < 1 || data.width > 1024 ||
+        !Number.isInteger(data.height) || data.height < 1 || data.height > 1024 ||
+        (!viewer && !(data.bytes instanceof ArrayBuffer)) ||
+        (viewer && data.bytes !== undefined)) {
+      return;
+    }
+    active = true;
+    let handle = null;
+    let initializing = false;
+    try {
+      if (!viewer) {
+        initializing = true;
+        const parseRoot = document.getElementById("parse");
+        viewer = await ay.open(data.bytes, parseRoot, {
+          renderMode: "slide",
+          width: data.width,
+          fitMode: "contain",
+          zipLimits: fH,
+          lazyMedia: true,
+          lazySlides: true,
+          pdfjs: false,
+        });
+        initializing = false;
+      }
+      if (data.slideIndex >= viewer.slideCount) throw new Error("slide unavailable");
+      const root = document.getElementById("thumb");
+      root.innerHTML = "";
+      handle = viewer.renderThumbnailToContainer(data.slideIndex, root, {
+        width: data.width,
+        height: data.height,
+      });
+      if (!handle) throw new Error("slide unavailable");
+      await handle.ready;
+      const dataUrl = await rasterize(handle.element);
+      reply({ status: "thumb", index: data.slideIndex, dataUrl });
+    } catch (_) {
+      if (initializing) viewer = null;
+      reply({ status: "error", index: data.slideIndex, message: initializing ? "init" : "render" });
+    } finally {
+      if (handle) handle.dispose();
+      document.getElementById("thumb").innerHTML = "";
+      active = false;
+    }
+  });
+
+  reply({ status: "ready" });
+}
+
 const pptxRendererSourceEl = $("#pptx-renderer-source");
 // The wrapper contributes one newline on each side; remove only those two so
 // the bytes inserted into srcdoc still match the recorded vendor SHA-256.
@@ -41925,6 +42427,17 @@ function pptxRendererSrcdoc() {
   return '<!doctype html><html><head><meta charset="utf-8">' +
     '<meta http-equiv="Content-Security-Policy" content="' + PPTX_IFRAME_CSP + '">' +
     "<style>" + style + "</style></head><body><div id=\"slide\"></div>" +
+    '<script type="module">' + PPTX_RENDERER_SOURCE + glue + "</scr" + "ipt></body></html>";
+}
+
+function pptxThumbRendererSrcdoc() {
+  const style = "html,body{margin:0;width:100%;height:100%;overflow:hidden;background:#f2eee5}" +
+    "#parse{position:absolute;left:-10000px;top:0}" +
+    "#thumb{position:relative;overflow:hidden;background:#f2eee5}";
+  const glue = ";(" + pptxThumbIframeMain.toString() + ")();";
+  return '<!doctype html><html><head><meta charset="utf-8">' +
+    '<meta http-equiv="Content-Security-Policy" content="' + PPTX_IFRAME_CSP + '">' +
+    "<style>" + style + "</style></head><body><div id=\"parse\"></div><div id=\"thumb\"></div>" +
     '<script type="module">' + PPTX_RENDERER_SOURCE + glue + "</scr" + "ipt></body></html>";
 }
 

--- a/crates/docray-server/tests/sync_api.rs
+++ b/crates/docray-server/tests/sync_api.rs
@@ -98,6 +98,26 @@ fn playground_pptx_source_isolation_contract() {
 }
 
 #[test]
+fn playground_pptx_thumbnail_isolation_contract() {
+    let html = include_str!("../assets/playground.html");
+    assert!(html.contains("iframe.setAttribute(\"sandbox\", PPTX_IFRAME_SANDBOX);"));
+    assert!(!html.contains("allow-same-origin"));
+    assert!(html.contains("iframe.srcdoc = pptxThumbRendererSrcdoc();"));
+    assert!(html.contains("event.source !== iframe.contentWindow || event.origin !== \"null\""));
+    assert!(html.contains("data.index !== active.request.index"));
+    assert!(html.contains("PPTX_THUMB_DATA_URL_MAX = 3 * 1024 * 1024"));
+    assert!(html.contains("value.startsWith(\"data:image/png;base64,\")"));
+    assert!(html.contains("value.startsWith(\"data:image/webp;base64,\")"));
+    assert!(html.contains("image.src = dataUrl;"));
+    assert!(!html.contains("innerHTML = dataUrl"));
+    assert!(html.contains("cmd: \"renderThumb\""));
+    assert!(html.contains("[bytes]"));
+    assert!(html.contains("viewer.renderThumbnailToContainer(data.slideIndex"));
+    assert!(html.contains("pptxThumbCacheBytes <= PPTX_THUMB_BYTE_CAP"));
+    assert!(html.contains("image.dataset.thumbKind = \"rendered\";"));
+}
+
+#[test]
 fn healthz_and_sync_extract_and_errors() {
     let server = TestServer::start();
 


### PR DESCRIPTION
## What
The left-rail thumbnails for a PPTX now show the sandboxed renderer's visual output (matching SOURCE) instead of the structure schematic. PDF thumbnails unchanged (pdf.js).

## How, without weakening isolation
The parent can't read pixels out of the null-origin render iframe, so a dedicated **offscreen thumbnail iframe** (same `allow-scripts`-only sandbox + same CSP as the SOURCE iframe) parses the deck once and renders slides on demand, exporting each as an **inert, size-capped image data-URL** posted to the parent.
- Parent validates the new `{status:"thumb", index, dataUrl}` message strictly: `event.source`/`event.origin==="null"`, request-index equality, exact key set, and `dataUrl` must start with `data:image/png;base64,` or `data:image/webp;base64,` and be ≤ 3 MiB. The URL is used **only** as `new Image().src` (with an `onerror` fallback) — never innerHTML/markup.
- **Lazy**: renders only when a rail item scrolls into view (existing IntersectionObserver), through one reused iframe + sequential queue. LRU cache capped at 256 MiB (charged by encoded/decoded bytes), 16384px dimension cap.
- **Fallback**: a malformed slide, decode error, or per-thumb timeout falls back to that one slide's schematic thumbnail; iframe init failure falls the whole rail back to schematics. Never blank, never blocks.

## Verified (headless Chromium)
30-slide deck: first 10 rendered, 20 stayed placeholders (lazy); scrolling rendered the rest through the one iframe; a deliberately malformed slide fell back to schematic. All thumbnail replies had origin `null`, exact `{dataUrl,index,status}` keys, valid WebP prefixes; the frame couldn't read `parent.location`; `fetch` blocked (no network). PDF upload restored pdf.js thumbnails. Cost: ~349ms cold to first thumb, ~3ms median between subsequent thumbs on a simple deck; large/real decks populate progressively on scroll.

Isolation contract test extended to pin the data-URL prefix/cap, index equality, img-only sink, and continued absence of `allow-same-origin`.

## Checks
fmt / clippy -D warnings / `cargo test --workspace` green; build-wasm (web+nodejs) + wasm-parity + build-try pass; fixtures deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)