### PR TITLE
Fix: PPTX rail thumbnails never render blank

### DIFF
--- a/crates/docray-server/assets/playground.html
+++ b/crates/docray-server/assets/playground.html
@@ -41840,9 +41840,15 @@ function renderPptxThumb(el, index, gen) {
     mountPptxThumbImage(el, index, cached.dataUrl, gen);
     return;
   }
+  // Show the schematic immediately as a baseline so the rail is never blank
+  // while the render is pending — on a large/heavy deck the sequential render
+  // queue can lag for many seconds. The rendered image upgrades this on
+  // success; on error/timeout the schematic simply remains.
+  if (!el.querySelector('img[data-thumb-kind="rendered"]')) {
+    mountPptxSchematicThumb(el, index, gen);
+  }
   const renderer = ensurePptxThumbRenderer(gen);
   if (!renderer) {
-    mountPptxSchematicThumb(el, index, gen);
     return;
   }
   renderer.queue.push({ el, index, gen, dimensions });


### PR DESCRIPTION
## Problem
On a large/heavy deck the left-rail thumbnails showed **blank** while their render was pending. The rendered-thumbnail path (Phase 3e) only fell back to the schematic on error/timeout, so during the (often multi-second) wait — the render queue is sequential and each think-cell slide is expensive — the rail item stayed blank. The center SOURCE render worked because it's just the one current page; the rail needs N sequential renders, so they lag.

## Fix
When a rail item scrolls into view, mount the **schematic immediately as a baseline** (instant, always works), then upgrade it to the rendered image when the queue reaches that slide. On error/timeout the schematic simply remains. The rail is never blank — worst case you see the schematic, best case it upgrades to the faithful render.

Playground-only JS change: no extraction, schema, or fixture changes; iframe isolation and the isolation-contract test are untouched. JS parses, server builds, isolation test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)