### PR TITLE
Release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "docray-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "docray-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "docray-model",
  "serde",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "docray-model"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pdf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pptx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "docray-server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "docray-model",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "docray-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "docray-core",
  "docray-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "0.1.0"
+version = "0.2.0"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Bump workspace version 0.1.0 -> 0.2.0 for the v0.2.0 release.

Since v0.1.1, docray gained: native PPTX extraction (element granularity, hidden-context channel), first-class tables, per-run text styles, chart/SmartArt content extraction with number-format-aware values, inherited layout/master shape extraction, hidden-shape skipping, and the sandboxed in-browser PPTX renderer + hybrid rail thumbnails in the playground. Granularity-shaped schema evolved 1.1 -> 1.5 (frozen no-parameter response stays 1.1 byte-identical).

Merging this, then tagging `v0.2.0` triggers the release workflow (4-platform archives + GHCR image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)