### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "docray-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "docray-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "docray-model",
  "serde",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "docray-model"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pdf"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pptx"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -514,7 +514,7 @@ dependencies = [
 
 [[package]]
 name = "docray-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "docray-model",
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "docray-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "docray-core",
  "docray-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "0.2.0"
+version = "0.3.0"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Bump workspace version 0.2.0 -> 0.3.0.

Since v0.2.0: first-class structured chart elements (schema 1.6), CLI `--version` and PPTX-defaults-to-element UX, and F2 AI ownership branding across docs/README/playground. Frozen 1.1 no-parameter PDF response remains byte-identical.

Merge, then tag `v0.3.0` to trigger the release workflow (4-platform archives + GHCR image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)