### PR TITLE
Point F2 logo at f2.ai, drop redundant 'F2 AI' text

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,6 @@ above, without any additional terms or conditions.
 ---
 
 <p align="center">
-  <a href="https://github.com/F2-AI-Inc"><img src="book/src/f2-logo.png" alt="F2 AI" width="40" height="40"></a><br>
-  <sub>Built by <a href="https://github.com/F2-AI-Inc">F2 AI</a></sub>
+  <sub>Built by</sub><br>
+  <a href="https://f2.ai"><img src="book/src/f2-logo.png" alt="F2 AI" width="40" height="40"></a>
 </p>

--- a/book/theme/docray.js
+++ b/book/theme/docray.js
@@ -21,17 +21,18 @@
     var footer = document.createElement("footer");
     footer.id = "f2-footer";
     var link = document.createElement("a");
-    link.href = "https://github.com/F2-AI-Inc";
+    link.href = "https://f2.ai";
     link.target = "_blank";
     link.rel = "noopener";
+    link.setAttribute("aria-label", "F2 AI");
+    var label = document.createElement("span");
+    label.textContent = "Built by";
     var img = document.createElement("img");
     img.src = root + "f2-logo.png";
     img.alt = "F2 AI";
     img.width = 26;
     img.height = 26;
-    var label = document.createElement("span");
-    label.textContent = "Built by F2 AI";
-    link.append(img, label);
+    link.append(label, img);
     footer.appendChild(link);
     main.appendChild(footer);
   }

--- a/crates/docray-server/assets/playground.html
+++ b/crates/docray-server/assets/playground.html
@@ -297,9 +297,8 @@
 
 <header>
   <div class="wordmark"><b>docray</b><span>playground</span></div>
-  <a class="f2-badge" href="https://github.com/F2-AI-Inc" target="_blank" rel="noopener" title="docray is built by F2 AI">
+  <a class="f2-badge" href="https://f2.ai" target="_blank" rel="noopener" aria-label="F2 AI" title="F2 AI">
     <svg width="18" height="18" viewBox="0 0 100 100" aria-hidden="true"><rect width="100" height="100" rx="20" fill="#000"/><text x="50" y="50" dy="0.35em" text-anchor="middle" font-family="'IBM Plex Mono', ui-monospace, monospace" font-weight="700" font-size="44" fill="#faf5ea">F2</text></svg>
-    <span>F2 AI</span>
   </a>
   <span class="doc-name" id="doc-name"></span>
   <span class="kv" id="doc-kv"></span>


### PR DESCRIPTION
The F2 logo already shows 'F2', so the adjacent 'F2 AI' text is redundant.

- **Playground header**: badge is now the logo alone (no 'F2 AI' text), linking to https://f2.ai (aria-label/title keep 'F2 AI' for accessibility).
- **Docs footer** + **README**: link to https://f2.ai; keep a 'Built by' caption beside the logo, drop the redundant 'F2 AI'.

Source-repo links (git-repository-url, install instructions) are unchanged. JS parses, book builds, playground isolation test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)