### PR TITLE
handle broken-pipe on stdout in docray-cli

### DIFF
--- a/crates/docray-cli/src/main.rs
+++ b/crates/docray-cli/src/main.rs
@@ -3,6 +3,7 @@ use docray_core::{check_granularity, sniff_format, Capabilities, ExtractError, E
 use docray_model::{Extraction, GranularExtraction, Granularity, OutputFormat};
 use docray_pdf::PdfExtractor;
 use docray_pptx::PptxExtractor;
+use std::io::Write;
 use std::process::ExitCode;
 use std::str::FromStr;
 
@@ -121,7 +122,7 @@ fn run_extract(
         .and_then(|()| backend.extract(&bytes, max_pages));
     match result {
         Ok(extraction) => {
-            match format {
+            let output = match format {
                 OutputFormat::Lean => {
                     let compact = match extraction
                         .with_granularity(granularity.expect("lean granularity is validated above"))
@@ -131,10 +132,10 @@ fn run_extract(
                             unreachable!("lean char granularity is rejected above")
                         }
                     };
-                    print!("{}", compact.to_lean());
+                    compact.to_lean()
                 }
                 OutputFormat::Json => {
-                    let json = if let Some(level) = granularity {
+                    let mut json = if let Some(level) = granularity {
                         if pretty {
                             serde_json::to_string_pretty(&extraction.with_granularity(level))
                         } else {
@@ -146,12 +147,32 @@ fn run_extract(
                         serde_json::to_string(&extraction)
                     }
                     .expect("model serialization cannot fail");
-                    println!("{json}");
+                    json.push('\n');
+                    json
                 }
-            }
-            ExitCode::SUCCESS
+            };
+            write_stdout(&output)
         }
         Err(e) => fail(&e),
+    }
+}
+
+/// Write extraction output to stdout without panicking on a closed pipe.
+///
+/// `println!` panics on EPIPE (Rust ignores SIGPIPE), so `docray extract x.pdf
+/// | head` would exit 101 with a panic message — outside the stable error
+/// contract. A broken pipe means the reader chose to stop and is a quiet
+/// success (the convention of cat/grep/ripgrep); any other stdout write
+/// failure maps to the documented io_error / exit 5.
+fn write_stdout(output: &str) -> ExitCode {
+    let mut stdout = std::io::stdout().lock();
+    match stdout
+        .write_all(output.as_bytes())
+        .and_then(|()| stdout.flush())
+    {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+        Err(e) => fail(&ExtractError::Io(format!("stdout: {e}"))),
     }
 }
 

--- a/crates/docray-cli/tests/cli.rs
+++ b/crates/docray-cli/tests/cli.rs
@@ -161,6 +161,35 @@ fn pptx_explicit_element_and_lean_work() {
 }
 
 #[test]
+fn closed_stdout_pipe_is_quiet_success_not_a_panic() {
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_docray"))
+        .env(
+            "DOCRAY_PDFIUM_DIR",
+            format!("{}/../../.pdfium/lib", env!("CARGO_MANIFEST_DIR")),
+        )
+        .arg("extract")
+        .arg(testdata("simple.pdf"))
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    // Close the pipe's read end now, long before extraction finishes, so the
+    // CLI's eventual stdout write hits EPIPE.
+    drop(child.stdout.take());
+    let output = child.wait_with_output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("panicked"),
+        "CLI panicked on closed stdout: {stderr}"
+    );
+    assert!(
+        output.status.success(),
+        "expected quiet success on closed stdout, got {:?} (stderr: {stderr})",
+        output.status
+    );
+}
+
+#[test]
 fn version_flag_reports_the_crate_version() {
     dps()
         .arg("--version")


### PR DESCRIPTION
## What & why

`docray extract file.pdf | head` panicked (`failed printing to stdout: Broken pipe`, exit 101) because Rust ignores SIGPIPE and the CLI printed via `println!`/`print!`. Output now goes through an explicit locked-stdout write: EPIPE is a quiet exit-0 success (cat/ripgrep convention); any other stdout write failure maps to the existing `io_error` / exit 5. Happy-path output bytes are unchanged.

## Contract impact

- [x] No change to the schema-1.1 (`char`) output — output bytes identical, only the write mechanism changed
- [x] Error codes / CLI exit codes unchanged — removes an out-of-contract exit 101 panic; no new codes
- [x] Golden diffs (if any) — none

## Gates (all must pass locally — CI re-checks)

- [x] Commits are signed off
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build -p docray-cli && cargo test --workspace` (run in `rust:1.88` Docker, Linux-canonical; local machine has no Rust toolchain)
- [x] `cargo run -p docray-pdf --example gen_fixtures` produces zero diffs
- [x] Docs in `book/` — no contract change, no update needed

## Tests

`closed_stdout_pipe_is_quiet_success_not_a_panic` in `crates/docray-cli/tests/cli.rs`: spawns the real binary, closes the stdout read end immediately, asserts exit 0 and no panic on stderr. Verified it fails on the pre-fix code (exit 101, Broken pipe panic).

## Golden changes (if any)

None.