### PR TITLE
docs: list docray-pptx and docray-wasm in the AGENTS.md repository map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,10 @@ agents (CLAUDE.md and .cursorrules are symlinks to it).
 | `crates/docray-model` | The serde JSON schema — the contract every consumer depends on |
 | `crates/docray-core` | `Extractor` trait, format sniffing, geometric char→word→line grouping |
 | `crates/docray-pdf` | PDFium-backed extractor (`pdfium-render`, pinned exact version) |
+| `crates/docray-pptx` | Pure-Rust OOXML (PPTX) extractor — a deliberate hostile-input boundary |
 | `crates/docray-cli` | `docray` binary — also the server's isolation worker subprocess |
 | `crates/docray-server` | axum HTTP: sync + async jobs; embedded playground at `/playground` |
+| `crates/docray-wasm` | Browser-facing `wasm32` build (PDF + PPTX); CI enforces WASM↔native parity |
 | `testdata/` | Generated fixtures + golden JSON (see skills below before touching) |
 | `book/` | Docs site (mdBook → GitHub Pages) |
 


### PR DESCRIPTION
## What

The repository-map table in `AGENTS.md` (the canonical agent-context file; `CLAUDE.md` and `.cursorrules` symlink to it) listed only 5 of the workspace's 7 crates. This adds the two that were missing:

- **`crates/docray-pptx`** — pure-Rust OOXML (PPTX) extractor, a deliberate hostile-input boundary
- **`crates/docray-wasm`** — browser-facing `wasm32` build (PDF + PPTX), with CI enforcing WASM↔native parity

## Why

`book/src/architecture.md` already documented `docray-pptx`, so the two docs had drifted. Since `AGENTS.md` is the map every coding agent reads first, an incomplete crate list is worth correcting. Descriptions are grounded in each crate's source and existing docs.

## Scope

Docs-only change to the agent-context file. No code, no JSON contract, no CLI/HTTP surface, no fixtures touched — nothing to test or regenerate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)