### PR TITLE
ci: let Dependabot track Cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,12 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+
+  # pdfium-render is excluded: it is pinned in lockstep with the pdfium binary
+  # in scripts/fetch-pdfium.sh (AGENTS.md rule 7), so bump it deliberately.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    ignore:
+      - dependency-name: "pdfium-render"


### PR DESCRIPTION
## What

Adds a `cargo` ecosystem to `.github/dependabot.yml` (weekly, matching the existing `github-actions` cadence) so Rust dependencies get automated update PRs.

## Why

Dependabot previously watched **only** GitHub Actions. The Cargo dependency tree (`serde`, `axum`, `thiserror`, and their transitive deps) received no update PRs and silently rotted — meaning security and bugfix releases landed only when someone happened to bump them by hand.

## The `pdfium-render` exclusion

`pdfium-render` is ignored entirely. Per AGENTS.md rule 7 it is pinned with `=` (`=0.8.37`) and must be bumped **in lockstep** with the pinned pdfium binary build in `scripts/fetch-pdfium.sh` — a coordination a PR-level version bump cannot perform, and doing it wrong is a determinism/ABI hazard. That crate stays a deliberate, reviewed change.

## Scope

CI-config-only change. No code, no workspace manifests, no lockfile touched here — Dependabot will open its own PRs, each of which runs the full existing CI suite (fmt, clippy, tests, determinism, wasm parity, docker smoke) before anything merges. Validated that the file still parses as valid YAML with both ecosystems present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)