### PR TITLE
Release v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "docray-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "docray-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "docray-model",
  "serde",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "docray-model"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pdf"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pptx"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "docray-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "axum",
  "docray-model",
@@ -631,7 +631,7 @@ dependencies = [
 
 [[package]]
 name = "docray-wasm"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "docray-core",
  "docray-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "0.3.0"
+version = "0.3.1"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Bump workspace version 0.3.0 -> 0.3.1.

Since v0.3.0: broken-pipe handling on stdout (`docray extract x | head` no longer panics — quiet success), F2 logo now links to f2.ai, and Cargo dependency bumps (sha2, uuid, tokio, libc, lopdf). No API or schema changes; the frozen 1.1 response is byte-identical (dependency bumps changed only fixture input-hash metadata).

Merge, then tag `v0.3.1` to trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)