### PR TITLE
Shared docray-ooxml crate + content-based OPC dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "clap",
  "docray-core",
  "docray-model",
+ "docray-ooxml",
  "docray-pdf",
  "docray-pptx",
  "predicates",
@@ -588,6 +589,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "docray-ooxml"
+version = "0.3.1"
+dependencies = [
+ "docray-core",
+ "quick-xml",
+ "zip",
+]
+
+[[package]]
 name = "docray-pdf"
 version = "0.3.1"
 dependencies = [
@@ -605,7 +615,7 @@ version = "0.3.1"
 dependencies = [
  "docray-core",
  "docray-model",
- "quick-xml",
+ "docray-ooxml",
  "serde_json",
  "sha2",
  "zip",
@@ -635,6 +645,7 @@ version = "0.3.1"
 dependencies = [
  "docray-core",
  "docray-model",
+ "docray-ooxml",
  "docray-pdf",
  "docray-pptx",
  "serde",

--- a/crates/docray-cli/Cargo.toml
+++ b/crates/docray-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 [dependencies]
 docray-model = { path = "../docray-model" }
 docray-core = { path = "../docray-core" }
+docray-ooxml = { path = "../docray-ooxml" }
 docray-pdf = { path = "../docray-pdf" }
 docray-pptx = { path = "../docray-pptx" }
 serde_json.workspace = true

--- a/crates/docray-cli/src/main.rs
+++ b/crates/docray-cli/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 use docray_core::{check_granularity, sniff_format, Capabilities, ExtractError, Extractor, Format};
 use docray_model::{Extraction, GranularExtraction, Granularity, OutputFormat};
+use docray_ooxml::{sniff_opc, OpcKind};
 use docray_pdf::PdfExtractor;
 use docray_pptx::PptxExtractor;
 use std::io::Write;
@@ -14,13 +15,14 @@ const CFB_MAGIC: &[u8; 8] = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1";
 enum Backend {
     Pdf,
     Pptx,
+    Zip,
 }
 
 impl Backend {
     fn capabilities(&self) -> Capabilities {
         match self {
             Backend::Pdf => PdfExtractor.capabilities(),
-            Backend::Pptx => PptxExtractor.capabilities(),
+            Backend::Pptx | Backend::Zip => PptxExtractor.capabilities(),
         }
     }
 
@@ -28,6 +30,10 @@ impl Backend {
         match self {
             Backend::Pdf => PdfExtractor.extract(bytes, max_pages),
             Backend::Pptx => PptxExtractor.extract(bytes, max_pages),
+            Backend::Zip => match sniff_opc(bytes)? {
+                OpcKind::Pptx => PptxExtractor.extract(bytes, max_pages),
+                OpcKind::Docx | OpcKind::OtherZip => Err(unsupported_zip()),
+            },
         }
     }
 }
@@ -103,7 +109,7 @@ fn run_extract(
     };
     let backend = match sniff_format(&bytes) {
         Some(Format::Pdf) => Backend::Pdf,
-        Some(Format::Zip) => Backend::Pptx,
+        Some(Format::Zip) => Backend::Zip,
         None if bytes.starts_with(CFB_MAGIC) => Backend::Pptx,
         None => return fail(&ExtractError::UnsupportedFormat),
     };
@@ -155,6 +161,10 @@ fn run_extract(
         }
         Err(e) => fail(&e),
     }
+}
+
+fn unsupported_zip() -> ExtractError {
+    ExtractError::UnsupportedFormatMessage("zip archive is not a PowerPoint file".into())
 }
 
 /// Write extraction output to stdout without panicking on a closed pipe.

--- a/crates/docray-ooxml/Cargo.toml
+++ b/crates/docray-ooxml/Cargo.toml
@@ -1,15 +1,10 @@
 [package]
-name = "docray-pptx"
+name = "docray-ooxml"
 edition.workspace = true
 license.workspace = true
 version.workspace = true
 
 [dependencies]
-docray-model = { path = "../docray-model" }
 docray-core = { path = "../docray-core" }
-docray-ooxml = { path = "../docray-ooxml" }
-sha2 = "0.11"
-
-[dev-dependencies]
-serde_json.workspace = true
+quick-xml = "=0.41.0"
 zip = { version = "=2.4.2", default-features = false, features = ["deflate"] }

--- a/crates/docray-ooxml/src/lib.rs
+++ b/crates/docray-ooxml/src/lib.rs
@@ -1,0 +1,95 @@
+mod package;
+mod relationships;
+mod xml;
+
+pub use package::{Package, MAX_COMPRESSION_RATIO, MAX_ENTRIES, MAX_ENTRY_SIZE, MAX_TOTAL_SIZE};
+pub use relationships::{relationships, resolve_target, Relationship, Relationships};
+pub use xml::{local_name, parse, Descendants, Node, MAX_XML_DEPTH, MAX_XML_NODES};
+
+use docray_core::ExtractError;
+
+pub const EMU_PER_POINT: f64 = 12_700.0;
+pub const TWIPS_PER_POINT: f64 = 20.0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpcKind {
+    Pptx,
+    Docx,
+    OtherZip,
+}
+
+pub fn sniff_opc(bytes: &[u8]) -> Result<OpcKind, ExtractError> {
+    let package = Package::open(bytes)?;
+    if package.contains("ppt/presentation.xml") {
+        Ok(OpcKind::Pptx)
+    } else if package.contains("word/document.xml") {
+        Ok(OpcKind::Docx)
+    } else {
+        Ok(OpcKind::OtherZip)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Cursor, Write};
+    use zip::write::SimpleFileOptions;
+    use zip::ZipWriter;
+
+    fn opc(parts: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+        for (name, bytes) in parts {
+            writer
+                .start_file(*name, SimpleFileOptions::default())
+                .unwrap();
+            writer.write_all(bytes).unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    #[test]
+    fn sniff_opc_classifies_pptx_and_pptm_by_main_part() {
+        let pptx = opc(&[("ppt/presentation.xml", b"<p:presentation/>")]);
+        assert_eq!(sniff_opc(&pptx).unwrap(), OpcKind::Pptx);
+
+        let pptm = opc(&[
+            ("ppt/presentation.xml", b"<p:presentation/>"),
+            (
+                "[Content_Types].xml",
+                b"<Types><Override PartName=\"/ppt/presentation.xml\" ContentType=\"application/vnd.ms-powerpoint.presentation.macroEnabled.main+xml\"/></Types>",
+            ),
+            ("ppt/vbaProject.bin", b"macros are not inspected"),
+        ]);
+        assert_eq!(sniff_opc(&pptm).unwrap(), OpcKind::Pptx);
+    }
+
+    #[test]
+    fn sniff_opc_classifies_docx_and_docm_by_main_part() {
+        let docx = opc(&[("word/document.xml", b"<w:document/>")]);
+        assert_eq!(sniff_opc(&docx).unwrap(), OpcKind::Docx);
+
+        let docm = opc(&[
+            ("word/document.xml", b"<w:document/>"),
+            (
+                "[Content_Types].xml",
+                b"<Types><Override PartName=\"/word/document.xml\" ContentType=\"application/vnd.ms-word.document.macroEnabled.main+xml\"/></Types>",
+            ),
+            ("word/vbaProject.bin", b"macros are not inspected"),
+        ]);
+        assert_eq!(sniff_opc(&docm).unwrap(), OpcKind::Docx);
+    }
+
+    #[test]
+    fn sniff_opc_classifies_plain_zip() {
+        let zip = opc(&[("notes.txt", b"not an OOXML package")]);
+        assert_eq!(sniff_opc(&zip).unwrap(), OpcKind::OtherZip);
+    }
+
+    #[test]
+    fn sniff_opc_applies_package_security_caps() {
+        let hostile = opc(&[("../ppt/presentation.xml", b"<p:presentation/>")]);
+        let error = sniff_opc(&hostile).unwrap_err();
+        assert_eq!(error.code(), "parse_failure");
+        assert!(error.to_string().contains("unsafe OPC entry name rejected"));
+    }
+}

--- a/crates/docray-ooxml/src/package.rs
+++ b/crates/docray-ooxml/src/package.rs
@@ -3,18 +3,18 @@ use std::collections::BTreeSet;
 use std::io::{Cursor, Read};
 use zip::ZipArchive;
 
-const MAX_ENTRIES: usize = 4096;
-const MAX_ENTRY_SIZE: u64 = 64 * 1024 * 1024;
-const MAX_TOTAL_SIZE: u64 = 512 * 1024 * 1024;
-const MAX_COMPRESSION_RATIO: u64 = 200;
+pub const MAX_ENTRIES: usize = 4096;
+pub const MAX_ENTRY_SIZE: u64 = 64 * 1024 * 1024;
+pub const MAX_TOTAL_SIZE: u64 = 512 * 1024 * 1024;
+pub const MAX_COMPRESSION_RATIO: u64 = 200;
 
-pub(crate) struct Package<'a> {
+pub struct Package<'a> {
     archive: ZipArchive<Cursor<&'a [u8]>>,
     bytes_read: u64,
 }
 
 impl<'a> Package<'a> {
-    pub(crate) fn open(bytes: &'a [u8]) -> Result<Self, ExtractError> {
+    pub fn open(bytes: &'a [u8]) -> Result<Self, ExtractError> {
         let mut archive = ZipArchive::new(Cursor::new(bytes))
             .map_err(|e| ExtractError::ParseFailure(format!("invalid ZIP container: {e}")))?;
         if archive.len() > MAX_ENTRIES {
@@ -71,13 +71,13 @@ impl<'a> Package<'a> {
         })
     }
 
-    pub(crate) fn contains(&self, name: &str) -> bool {
+    pub fn contains(&self, name: &str) -> bool {
         self.archive.index_for_name(name).is_some()
     }
 
     /// Reads a single exact OPC part. Entries are never extracted to disk and
     /// callers cannot request directory prefixes or wildcard matches.
-    pub(crate) fn read(&mut self, name: &str) -> Result<Option<Vec<u8>>, ExtractError> {
+    pub fn read(&mut self, name: &str) -> Result<Option<Vec<u8>>, ExtractError> {
         let Ok(mut entry) = self.archive.by_name(name) else {
             return Ok(None);
         };
@@ -113,7 +113,7 @@ impl<'a> Package<'a> {
         Ok(Some(bytes))
     }
 
-    pub(crate) fn read_required(&mut self, name: &str) -> Result<Vec<u8>, ExtractError> {
+    pub fn read_required(&mut self, name: &str) -> Result<Vec<u8>, ExtractError> {
         self.read(name)?.ok_or_else(|| {
             ExtractError::ParseFailure(format!("required OPC part is missing: {name}"))
         })

--- a/crates/docray-ooxml/src/relationships.rs
+++ b/crates/docray-ooxml/src/relationships.rs
@@ -1,0 +1,95 @@
+use crate::{parse, Package};
+use docray_core::ExtractError;
+use std::collections::BTreeMap;
+
+#[derive(Default)]
+pub struct Relationships {
+    by_id: BTreeMap<String, Relationship>,
+}
+
+pub struct Relationship {
+    pub target: String,
+    pub kind: String,
+    pub external: bool,
+}
+
+impl Relationships {
+    pub fn get(&self, id: &str) -> Option<&Relationship> {
+        self.by_id.get(id)
+    }
+
+    pub fn first_internal_type(&self, suffix: &str) -> Option<&Relationship> {
+        self.by_id
+            .values()
+            .find(|relation| !relation.external && relation.kind.rsplit('/').next() == Some(suffix))
+    }
+}
+
+pub fn relationships(
+    package: &mut Package<'_>,
+    source_part: &str,
+) -> Result<Relationships, ExtractError> {
+    let path = rels_path(source_part);
+    let Some(bytes) = package.read(&path)? else {
+        return Ok(Relationships::default());
+    };
+    let root = parse(&bytes, &path)?;
+    let mut relationships = Relationships::default();
+    for relation in root.descendants("Relationship") {
+        let Some(id) = relation.attr("Id") else {
+            continue;
+        };
+        let Some(target) = relation.attr("Target") else {
+            continue;
+        };
+        relationships.by_id.insert(
+            id.to_string(),
+            Relationship {
+                target: target.to_string(),
+                kind: relation.attr("Type").unwrap_or_default().to_string(),
+                external: relation.attr("TargetMode") == Some("External"),
+            },
+        );
+    }
+    Ok(relationships)
+}
+
+fn rels_path(source_part: &str) -> String {
+    match source_part.rsplit_once('/') {
+        Some((directory, file)) => format!("{directory}/_rels/{file}.rels"),
+        None => format!("_rels/{source_part}.rels"),
+    }
+}
+
+pub fn resolve_target(source_part: &str, target: &str) -> Result<String, ExtractError> {
+    let target = target
+        .split('#')
+        .next()
+        .unwrap_or(target)
+        .replace('\\', "/");
+    let mut parts: Vec<&str> = if target.starts_with('/') {
+        Vec::new()
+    } else {
+        source_part
+            .rsplit_once('/')
+            .map_or_else(Vec::new, |(dir, _)| dir.split('/').collect())
+    };
+    for part in target.trim_start_matches('/').split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                if parts.pop().is_none() {
+                    return Err(parse_failure(format!(
+                        "relationship target escapes the package root: {target:?}"
+                    )));
+                }
+            }
+            value => parts.push(value),
+        }
+    }
+    Ok(parts.join("/"))
+}
+
+fn parse_failure(message: impl Into<String>) -> ExtractError {
+    ExtractError::ParseFailure(message.into())
+}

--- a/crates/docray-ooxml/src/xml.rs
+++ b/crates/docray-ooxml/src/xml.rs
@@ -3,29 +3,37 @@ use quick_xml::events::Event;
 use quick_xml::Reader;
 use std::collections::BTreeMap;
 
-const MAX_XML_DEPTH: usize = 256;
+pub const MAX_XML_DEPTH: usize = 256;
 
 /// Bounds the parsed DOM independently of inflated byte size. A part's inflated
 /// bytes are already capped, but the `Node` tree is ~10-25x larger than its
 /// source, and the OPC compression-ratio guard is computed from spoofable
 /// central-directory sizes. This cap turns a DOM-amplification attempt into a
 /// clean `parse_failure` instead of relying on the worker memory rlimit.
-const MAX_XML_NODES: usize = 5_000_000;
+pub const MAX_XML_NODES: usize = 5_000_000;
+
+type Namespaces = BTreeMap<String, String>;
 
 #[derive(Debug, Clone)]
-pub(crate) struct Node {
-    pub(crate) name: String,
-    pub(crate) attrs: BTreeMap<String, String>,
-    pub(crate) children: Vec<Node>,
-    pub(crate) text: String,
+pub struct Node {
+    pub name: String,
+    pub attrs: BTreeMap<String, String>,
+    pub children: Vec<Node>,
+    pub text: String,
+    namespace_uri: Option<String>,
+    attr_namespace_uris: BTreeMap<String, String>,
 }
 
 impl Node {
-    pub(crate) fn local_name(&self) -> &str {
+    pub fn local_name(&self) -> &str {
         local_name(&self.name)
     }
 
-    pub(crate) fn attr(&self, name: &str) -> Option<&str> {
+    pub fn namespace_uri(&self) -> Option<&str> {
+        self.namespace_uri.as_deref()
+    }
+
+    pub fn attr(&self, name: &str) -> Option<&str> {
         self.attrs
             .get(name)
             .or_else(|| {
@@ -37,29 +45,43 @@ impl Node {
             .map(String::as_str)
     }
 
-    pub(crate) fn child(&self, local: &str) -> Option<&Node> {
+    pub fn attr_ns(&self, namespace_uri: &str, local: &str) -> Option<&str> {
+        self.attrs.iter().find_map(|(key, value)| {
+            (local_name(key) == local
+                && self.attr_namespace_uris.get(key).map(String::as_str) == Some(namespace_uri))
+            .then_some(value.as_str())
+        })
+    }
+
+    pub fn child(&self, local: &str) -> Option<&Node> {
         self.children.iter().find(|node| node.local_name() == local)
     }
 
-    pub(crate) fn children_named<'a>(&'a self, local: &'a str) -> impl Iterator<Item = &'a Node> {
+    pub fn child_ns(&self, namespace_uri: &str, local: &str) -> Option<&Node> {
+        self.children
+            .iter()
+            .find(|node| node.local_name() == local && node.namespace_uri() == Some(namespace_uri))
+    }
+
+    pub fn children_named<'a>(&'a self, local: &'a str) -> impl Iterator<Item = &'a Node> {
         self.children
             .iter()
             .filter(move |node| node.local_name() == local)
     }
 
-    pub(crate) fn descendants<'a, 'b>(&'a self, local: &'b str) -> Descendants<'a, 'b> {
+    pub fn descendants<'a, 'b>(&'a self, local: &'b str) -> Descendants<'a, 'b> {
         Descendants {
             stack: self.children.iter().rev().collect(),
             local,
         }
     }
 
-    pub(crate) fn first_descendant(&self, local: &str) -> Option<&Node> {
+    pub fn first_descendant(&self, local: &str) -> Option<&Node> {
         self.descendants(local).next()
     }
 }
 
-pub(crate) struct Descendants<'a, 'b> {
+pub struct Descendants<'a, 'b> {
     stack: Vec<&'a Node>,
     local: &'b str,
 }
@@ -78,7 +100,7 @@ impl<'a, 'b> Iterator for Descendants<'a, 'b> {
     }
 }
 
-pub(crate) fn parse(bytes: &[u8], part: &str) -> Result<Node, ExtractError> {
+pub fn parse(bytes: &[u8], part: &str) -> Result<Node, ExtractError> {
     parse_with_limits(bytes, part, MAX_XML_NODES)
 }
 
@@ -87,6 +109,7 @@ fn parse_with_limits(bytes: &[u8], part: &str, max_nodes: usize) -> Result<Node,
     reader.config_mut().check_end_names = true;
     reader.config_mut().trim_text(false);
     let mut stack: Vec<Node> = Vec::new();
+    let mut namespace_stack: Vec<Namespaces> = Vec::new();
     let mut root = None;
     let mut node_count = 0_usize;
 
@@ -100,30 +123,30 @@ fn parse_with_limits(bytes: &[u8], part: &str, max_nodes: usize) -> Result<Node,
                 if node_count > max_nodes {
                     return Err(parse_error(part, "XML element count limit exceeded"));
                 }
-                stack.push(Node {
-                    name: decode(start.name().as_ref(), part)?,
-                    attrs: attributes(&start, reader.decoder(), part)?,
-                    children: Vec::new(),
-                    text: String::new(),
-                });
+                let attrs = attributes(&start, reader.decoder(), part)?;
+                let namespaces = namespaces_for_element(namespace_stack.last(), &attrs);
+                stack.push(make_node(
+                    decode(start.name().as_ref(), part)?,
+                    attrs,
+                    &namespaces,
+                ));
+                namespace_stack.push(namespaces);
             }
             Ok(Event::Empty(empty)) => {
                 node_count += 1;
                 if node_count > max_nodes {
                     return Err(parse_error(part, "XML element count limit exceeded"));
                 }
-                let node = Node {
-                    name: decode(empty.name().as_ref(), part)?,
-                    attrs: attributes(&empty, reader.decoder(), part)?,
-                    children: Vec::new(),
-                    text: String::new(),
-                };
+                let attrs = attributes(&empty, reader.decoder(), part)?;
+                let namespaces = namespaces_for_element(namespace_stack.last(), &attrs);
+                let node = make_node(decode(empty.name().as_ref(), part)?, attrs, &namespaces);
                 attach(node, &mut stack, &mut root, part)?;
             }
             Ok(Event::End(_)) => {
                 let node = stack
                     .pop()
                     .ok_or_else(|| parse_error(part, "unexpected XML end tag"))?;
+                namespace_stack.pop();
                 attach(node, &mut stack, &mut root, part)?;
             }
             Ok(Event::Text(text)) => {
@@ -156,6 +179,67 @@ fn parse_with_limits(bytes: &[u8], part: &str, max_nodes: usize) -> Result<Node,
         return Err(parse_error(part, "unclosed XML element"));
     }
     root.ok_or_else(|| parse_error(part, "XML document has no root element"))
+}
+
+fn make_node(name: String, attrs: BTreeMap<String, String>, namespaces: &Namespaces) -> Node {
+    let namespace_uri = namespace_for_name(&name, namespaces, false).map(str::to_owned);
+    let attr_namespace_uris = attrs
+        .keys()
+        .filter_map(|key| {
+            namespace_for_name(key, namespaces, true).map(|uri| (key.clone(), uri.to_owned()))
+        })
+        .collect();
+    Node {
+        name,
+        attrs,
+        children: Vec::new(),
+        text: String::new(),
+        namespace_uri,
+        attr_namespace_uris,
+    }
+}
+
+fn namespaces_for_element(
+    parent: Option<&Namespaces>,
+    attrs: &BTreeMap<String, String>,
+) -> Namespaces {
+    let mut namespaces = parent.cloned().unwrap_or_else(|| {
+        BTreeMap::from([(
+            "xml".to_string(),
+            "http://www.w3.org/XML/1998/namespace".to_string(),
+        )])
+    });
+    for (key, value) in attrs {
+        if key == "xmlns" {
+            if value.is_empty() {
+                namespaces.remove("");
+            } else {
+                namespaces.insert(String::new(), value.clone());
+            }
+        } else if let Some(prefix) = key.strip_prefix("xmlns:") {
+            if value.is_empty() {
+                namespaces.remove(prefix);
+            } else {
+                namespaces.insert(prefix.to_string(), value.clone());
+            }
+        }
+    }
+    namespaces
+}
+
+fn namespace_for_name<'a>(
+    name: &str,
+    namespaces: &'a Namespaces,
+    attribute: bool,
+) -> Option<&'a str> {
+    if name == "xmlns" || name.starts_with("xmlns:") {
+        return Some("http://www.w3.org/2000/xmlns/");
+    }
+    match name.rsplit_once(':') {
+        Some((prefix, _)) => namespaces.get(prefix).map(String::as_str),
+        None if !attribute => namespaces.get("").map(String::as_str),
+        None => None,
+    }
 }
 
 fn attributes(
@@ -232,7 +316,7 @@ fn parse_error(part: &str, message: &str) -> ExtractError {
     ExtractError::ParseFailure(format!("{part}: {message}"))
 }
 
-pub(crate) fn local_name(name: &str) -> &str {
+pub fn local_name(name: &str) -> &str {
     name.rsplit_once(':').map_or(name, |(_, local)| local)
 }
 
@@ -265,5 +349,19 @@ mod tests {
         let node = parse_with_limits(b"<root><a/><a/><a/><a/></root>", "test.xml", 5).unwrap();
         assert_eq!(node.local_name(), "root");
         assert_eq!(node.children.len(), 4);
+    }
+
+    #[test]
+    fn namespace_lookups_resolve_in_scope_prefixes() {
+        let root = parse(
+            br#"<w:document xmlns:w="urn:word" xmlns:r="urn:rels"><w:body><w:p r:id="rId1"/><other:p r:id="wrong" xmlns:other="urn:other"/></w:body></w:document>"#,
+            "test.xml",
+        )
+        .unwrap();
+        let body = root.child_ns("urn:word", "body").unwrap();
+        let paragraph = body.child_ns("urn:word", "p").unwrap();
+        assert_eq!(paragraph.namespace_uri(), Some("urn:word"));
+        assert_eq!(paragraph.attr_ns("urn:rels", "id"), Some("rId1"));
+        assert!(body.child_ns("urn:missing", "p").is_none());
     }
 }

--- a/crates/docray-pptx/src/extract.rs
+++ b/crates/docray-pptx/src/extract.rs
@@ -1,15 +1,15 @@
-use crate::package::Package;
-use crate::xml::{parse, Node};
 use docray_core::{Capabilities, ExtractError, Extractor};
 use docray_model::{
     round3, AnnotationElement, BBox, ChartElement, ChartPoint, ChartSeries, DocMetadata,
     DocumentInfo, Element, Extraction, Font, Granularity, HiddenItem, ImageElement, Page,
     PathElement, Source, TableCell, TableElement, TextColor, TextElement, TextRun,
 };
+use docray_ooxml::{
+    parse, relationships, resolve_target, Node, Package, Relationships, EMU_PER_POINT,
+};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
-const EMU_PER_POINT: f64 = 12_700.0;
 /// Fallback height for a table row with no authored height in a zero-height
 /// frame (~0.3in). Used only to keep auto-sized table content, with a warning.
 const DEFAULT_AUTO_ROW_EMU: f64 = 274_320.0;
@@ -1882,94 +1882,6 @@ fn has_geometry(shape: &Node) -> bool {
     shape.child("spPr").is_some_and(|properties| {
         properties.child("prstGeom").is_some() || properties.child("custGeom").is_some()
     })
-}
-
-#[derive(Default)]
-struct Relationships {
-    by_id: BTreeMap<String, Relationship>,
-}
-
-struct Relationship {
-    target: String,
-    kind: String,
-    external: bool,
-}
-
-impl Relationships {
-    fn get(&self, id: &str) -> Option<&Relationship> {
-        self.by_id.get(id)
-    }
-
-    fn first_internal_type(&self, suffix: &str) -> Option<&Relationship> {
-        self.by_id
-            .values()
-            .find(|relation| !relation.external && relation.kind.rsplit('/').next() == Some(suffix))
-    }
-}
-
-fn relationships(
-    package: &mut Package<'_>,
-    source_part: &str,
-) -> Result<Relationships, ExtractError> {
-    let path = rels_path(source_part);
-    let Some(bytes) = package.read(&path)? else {
-        return Ok(Relationships::default());
-    };
-    let root = parse(&bytes, &path)?;
-    let mut relationships = Relationships::default();
-    for relation in root.descendants("Relationship") {
-        let Some(id) = relation.attr("Id") else {
-            continue;
-        };
-        let Some(target) = relation.attr("Target") else {
-            continue;
-        };
-        relationships.by_id.insert(
-            id.to_string(),
-            Relationship {
-                target: target.to_string(),
-                kind: relation.attr("Type").unwrap_or_default().to_string(),
-                external: relation.attr("TargetMode") == Some("External"),
-            },
-        );
-    }
-    Ok(relationships)
-}
-
-fn rels_path(source_part: &str) -> String {
-    match source_part.rsplit_once('/') {
-        Some((directory, file)) => format!("{directory}/_rels/{file}.rels"),
-        None => format!("_rels/{source_part}.rels"),
-    }
-}
-
-fn resolve_target(source_part: &str, target: &str) -> Result<String, ExtractError> {
-    let target = target
-        .split('#')
-        .next()
-        .unwrap_or(target)
-        .replace('\\', "/");
-    let mut parts: Vec<&str> = if target.starts_with('/') {
-        Vec::new()
-    } else {
-        source_part
-            .rsplit_once('/')
-            .map_or_else(Vec::new, |(dir, _)| dir.split('/').collect())
-    };
-    for part in target.trim_start_matches('/').split('/') {
-        match part {
-            "" | "." => {}
-            ".." => {
-                if parts.pop().is_none() {
-                    return Err(parse_failure(format!(
-                        "relationship target escapes the package root: {target:?}"
-                    )));
-                }
-            }
-            value => parts.push(value),
-        }
-    }
-    Ok(parts.join("/"))
 }
 
 fn xml_required(package: &mut Package<'_>, path: &str) -> Result<Node, ExtractError> {

--- a/crates/docray-pptx/src/lib.rs
+++ b/crates/docray-pptx/src/lib.rs
@@ -1,6 +1,3 @@
-mod package;
-mod xml;
-
 pub use extract::PptxExtractor;
 
 mod extract;

--- a/crates/docray-wasm/Cargo.toml
+++ b/crates/docray-wasm/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 docray-core = { path = "../docray-core" }
 docray-model = { path = "../docray-model" }
+docray-ooxml = { path = "../docray-ooxml" }
 docray-pdf = { path = "../docray-pdf" }
 docray-pptx = { path = "../docray-pptx" }
 serde.workspace = true

--- a/crates/docray-wasm/src/lib.rs
+++ b/crates/docray-wasm/src/lib.rs
@@ -11,6 +11,7 @@
 
 use docray_core::{check_granularity, sniff_format, ExtractError, Extractor, Format};
 use docray_model::{Extraction, GranularExtraction, Granularity};
+use docray_ooxml::{sniff_opc, OpcKind};
 use docray_pdf::PdfExtractor;
 use docray_pptx::PptxExtractor;
 use wasm_bindgen::prelude::*;
@@ -140,8 +141,14 @@ fn extract_document(bytes: &[u8], requested: Option<Granularity>) -> Result<Extr
         }
         Some(Format::Zip) => {
             let extractor = PptxExtractor;
-            check_granularity(&extractor.capabilities(), requested)
-                .and_then(|()| extractor.extract(bytes, None))
+            check_granularity(&extractor.capabilities(), requested).and_then(|()| match sniff_opc(
+                bytes,
+            )? {
+                OpcKind::Pptx => extractor.extract(bytes, None),
+                OpcKind::Docx | OpcKind::OtherZip => Err(ExtractError::UnsupportedFormatMessage(
+                    "zip archive is not a PowerPoint file".into(),
+                )),
+            })
         }
         None if bytes.starts_with(CFB_MAGIC) => PptxExtractor.extract(bytes, None),
         None => Err(ExtractError::UnsupportedFormat),


### PR DESCRIPTION
Phase 0 of DOCX support — pure plumbing, **zero observable behavior change**.

## What
- New workspace crate `docray-ooxml`: the hardened OPC/XML machinery moves out of `docray-pptx` — `Package` (all existing caps intact: entry count/size/ratio, path-traversal + duplicate rejection, actual-read re-validation), the capped XXE-off XML parser, `Relationships` + `resolve_target`, unit conversions. Adds namespace-aware lookups (`attr_ns`/`child_ns` with proper prefix resolution) alongside the existing local-name paths — PPTX keeps using the latter unchanged.
- `sniff_opc(bytes) -> Pptx | Docx | OtherZip`: ZIP inputs are now classified by content (`ppt/presentation.xml` vs `word/document.xml`, under the same caps) instead of assuming PPTX. Phase 0 behavior is identical: Pptx routes as before; Docx/OtherZip produce the exact same `unsupported_format` error ("zip archive is not a PowerPoint file"); hostile zips keep their existing parse_failure paths.

## Zero-change evidence
No test assertion edited; `cargo test --workspace` green (30 suites); all goldens byte-identical (pre/post SHA-256 on all 27 JSON goldens); fixture generators diff-free; wasm build + parity green; docker smoke green. Verified independently by reviewer.

New tests cover only the new surface: the `sniff_opc` matrix (pptx/pptm/docx/docm/plain/hostile) and namespace resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)