### PR TITLE
Flow IR + schema 1.7 (docray-model)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,9 @@ Docker build/smoke test.
 1. **Schema stability.** The no-parameter (`char`) response is frozen at
    schema `1.1` and must stay **byte-identical**: never add, rename, remove,
    or reorder fields on that path. Granularity-shaped responses are schema
-   `1.6`. New capability = new field behind a parameter, or a minor version
-   bump with explicit review. Hidden-channel kind strings (`role`, `notes`,
+   `1.6`; flow-shaped responses are schema `1.7`. New capability = new field
+   behind a parameter, or a minor version bump with explicit review.
+   Hidden-channel kind strings (`role`, `notes`,
    `alt`, `hidden-slide`, `source-layer`) are also stable contract and must
    never be renamed.
 2. **Determinism.** Identical input bytes → byte-identical JSON on a given

--- a/crates/docray-cli/src/main.rs
+++ b/crates/docray-cli/src/main.rs
@@ -130,15 +130,15 @@ fn run_extract(
         Ok(extraction) => {
             let output = match format {
                 OutputFormat::Lean => {
-                    let compact = match extraction
+                    match extraction
                         .with_granularity(granularity.expect("lean granularity is validated above"))
                     {
-                        GranularExtraction::Compact(compact) => compact,
+                        GranularExtraction::Compact(compact) => compact.to_lean(),
+                        GranularExtraction::Flow(flow) => flow.to_lean(),
                         GranularExtraction::Char(_) => {
                             unreachable!("lean char granularity is rejected above")
                         }
-                    };
-                    compact.to_lean()
+                    }
                 }
                 OutputFormat::Json => {
                     let mut json = if let Some(level) = granularity {

--- a/crates/docray-core/src/lib.rs
+++ b/crates/docray-core/src/lib.rs
@@ -12,6 +12,14 @@ use docray_model::{Extraction, Granularity};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Capabilities {
     pub finest_granularity: Granularity,
+    pub geometry: GeometryKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GeometryKind {
+    Exact,
+    Container,
+    Flow,
 }
 
 pub trait Extractor {
@@ -47,6 +55,7 @@ mod tests {
         fn capabilities(&self) -> Capabilities {
             Capabilities {
                 finest_granularity: Granularity::Element,
+                geometry: GeometryKind::Flow,
             }
         }
 
@@ -86,5 +95,6 @@ mod tests {
             check_granularity(&capabilities, Some(Granularity::Element)),
             Ok(())
         );
+        assert_eq!(capabilities.geometry, GeometryKind::Flow);
     }
 }

--- a/crates/docray-model/src/flow.rs
+++ b/crates/docray-model/src/flow.rs
@@ -1,0 +1,611 @@
+use super::{
+    compact_color, compact_font, escape_text, lean_number, write_lean_runs, CompactDocMetadata,
+    CompactTextRun, DocMetadata, GranularExtraction, Granularity, HiddenItem, Source, TextRun,
+};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A document whose authored structure is flow-based rather than paged.
+///
+/// Block IDs use the stable `s{section}-b{index}` convention. Hidden items
+/// may target those IDs through [`HiddenItem::element`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FlowExtraction {
+    pub schema_version: String,
+    pub layout: FlowLayout,
+    pub source: Source,
+    pub document: FlowDocumentInfo,
+    pub warnings: Vec<String>,
+    pub approx_pages: Option<u32>,
+    pub sections: Vec<Section>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlowLayout {
+    Flow,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FlowDocumentInfo {
+    pub metadata: DocMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Section {
+    pub page_width: f64,
+    pub page_height: f64,
+    pub margins: Margins,
+    pub columns: Option<u32>,
+    pub headers: Vec<Story>,
+    pub footers: Vec<Story>,
+    pub blocks: Vec<Block>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub hidden: Vec<HiddenItem>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Margins {
+    pub top: f64,
+    pub right: f64,
+    pub bottom: f64,
+    pub left: f64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "variant", rename_all = "snake_case")]
+pub enum Story {
+    Default { blocks: Vec<Block> },
+    First { blocks: Vec<Block> },
+    Even { blocks: Vec<Block> },
+}
+
+impl Story {
+    fn blocks(&self) -> &[Block] {
+        match self {
+            Story::Default { blocks } | Story::First { blocks } | Story::Even { blocks } => blocks,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Block {
+    Paragraph {
+        id: String,
+        role: String,
+        runs: Vec<TextRun>,
+        content: String,
+        list: Option<ListInfo>,
+        placement: Option<Placement>,
+        approx_page: Option<u32>,
+        breaks_before: Vec<BreakKind>,
+    },
+    Table {
+        id: String,
+        col_widths: Vec<f64>,
+        rows: usize,
+        cols: usize,
+        cells: Vec<FlowTableCell>,
+    },
+    Image {
+        id: String,
+        width: Option<f64>,
+        height: Option<f64>,
+        content_hash: Option<String>,
+        placement: Option<Placement>,
+    },
+    Textbox {
+        id: String,
+        placement: Option<Placement>,
+        blocks: Vec<Block>,
+    },
+    Break {
+        kind: BreakKind,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ListInfo {
+    pub list_id: String,
+    pub level: u32,
+    pub kind: ListKind,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ListKind {
+    Ordered,
+    Bullet,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FlowTableCell {
+    pub row: usize,
+    pub col: usize,
+    pub row_span: usize,
+    pub col_span: usize,
+    pub content: String,
+    pub runs: Vec<TextRun>,
+    pub blocks: Option<Vec<Block>>,
+}
+
+/// Authored placement constraints. These values are never resolved into a
+/// bounding box because flow layout requires an external layout engine.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Placement {
+    pub frame: PlacementFrame,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub width: Option<f64>,
+    pub height: Option<f64>,
+    pub align_h: Option<String>,
+    pub align_v: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlacementFrame {
+    Page,
+    Margin,
+    Column,
+    Paragraph,
+    Line,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BreakKind {
+    Page,
+    Column,
+    Section,
+}
+
+#[derive(Serialize)]
+pub struct CompactFlowExtraction {
+    pub granularity: Granularity,
+    pub schema_version: &'static str,
+    pub layout: FlowLayout,
+    pub source: Source,
+    pub document: CompactFlowDocumentInfo,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approx_pages: Option<u32>,
+    pub sections: Vec<CompactSection>,
+}
+
+#[derive(Serialize)]
+pub struct CompactFlowDocumentInfo {
+    pub metadata: CompactDocMetadata,
+}
+
+#[derive(Serialize)]
+pub struct CompactSection {
+    pub page_width: f64,
+    pub page_height: f64,
+    pub margins: Margins,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub columns: Option<u32>,
+    pub headers: Vec<CompactStory>,
+    pub footers: Vec<CompactStory>,
+    pub blocks: Vec<CompactBlock>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub hidden: Vec<HiddenItem>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "variant", rename_all = "snake_case")]
+pub enum CompactStory {
+    Default { blocks: Vec<CompactBlock> },
+    First { blocks: Vec<CompactBlock> },
+    Even { blocks: Vec<CompactBlock> },
+}
+
+impl CompactStory {
+    fn blocks(&self) -> &[CompactBlock] {
+        match self {
+            CompactStory::Default { blocks }
+            | CompactStory::First { blocks }
+            | CompactStory::Even { blocks } => blocks,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CompactBlock {
+    Paragraph {
+        id: String,
+        role: String,
+        runs: Vec<CompactTextRun>,
+        content: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        list: Option<ListInfo>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        placement: Option<Placement>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        approx_page: Option<u32>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        breaks_before: Vec<BreakKind>,
+    },
+    Table {
+        id: String,
+        col_widths: Vec<f64>,
+        rows: usize,
+        cols: usize,
+        cells: Vec<CompactFlowTableCell>,
+    },
+    Image {
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        width: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        height: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        content_hash: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        placement: Option<Placement>,
+    },
+    Textbox {
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        placement: Option<Placement>,
+        blocks: Vec<CompactBlock>,
+    },
+    Break {
+        kind: BreakKind,
+    },
+}
+
+#[derive(Serialize)]
+pub struct CompactFlowTableCell {
+    pub row: usize,
+    pub col: usize,
+    pub row_span: usize,
+    pub col_span: usize,
+    pub content: String,
+    pub runs: Vec<CompactTextRun>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocks: Option<Vec<CompactBlock>>,
+}
+
+impl FlowExtraction {
+    /// Produces the only supported compact projection for a flow document.
+    /// Finer requests return `None`; callers normally reject them through the
+    /// extractor capability gate before reaching this method.
+    pub fn with_granularity(&self, granularity: Granularity) -> Option<GranularExtraction<'_>> {
+        if granularity != Granularity::Element {
+            return None;
+        }
+
+        Some(GranularExtraction::Flow(CompactFlowExtraction {
+            granularity,
+            schema_version: "1.7",
+            layout: FlowLayout::Flow,
+            source: self.source.clone(),
+            document: CompactFlowDocumentInfo {
+                metadata: CompactDocMetadata {
+                    title: self.document.metadata.title.clone(),
+                    author: self.document.metadata.author.clone(),
+                },
+            },
+            warnings: self.warnings.clone(),
+            approx_pages: self.approx_pages,
+            sections: self.sections.iter().map(compact_section).collect(),
+        }))
+    }
+}
+
+fn compact_section(section: &Section) -> CompactSection {
+    CompactSection {
+        page_width: super::round1(section.page_width),
+        page_height: super::round1(section.page_height),
+        margins: compact_margins(section.margins),
+        columns: section.columns,
+        headers: section.headers.iter().map(compact_story).collect(),
+        footers: section.footers.iter().map(compact_story).collect(),
+        blocks: section.blocks.iter().map(compact_block).collect(),
+        hidden: section.hidden.clone(),
+    }
+}
+
+fn compact_margins(margins: Margins) -> Margins {
+    Margins {
+        top: super::round1(margins.top),
+        right: super::round1(margins.right),
+        bottom: super::round1(margins.bottom),
+        left: super::round1(margins.left),
+    }
+}
+
+fn compact_story(story: &Story) -> CompactStory {
+    let blocks = || story.blocks().iter().map(compact_block).collect();
+    match story {
+        Story::Default { .. } => CompactStory::Default { blocks: blocks() },
+        Story::First { .. } => CompactStory::First { blocks: blocks() },
+        Story::Even { .. } => CompactStory::Even { blocks: blocks() },
+    }
+}
+
+fn compact_block(block: &Block) -> CompactBlock {
+    match block {
+        Block::Paragraph {
+            id,
+            role,
+            runs,
+            content,
+            list,
+            placement,
+            approx_page,
+            breaks_before,
+        } => CompactBlock::Paragraph {
+            id: id.clone(),
+            role: role.clone(),
+            runs: runs.iter().map(compact_run).collect(),
+            content: content.clone(),
+            list: list.clone(),
+            placement: placement.as_ref().map(compact_placement),
+            approx_page: *approx_page,
+            breaks_before: breaks_before.clone(),
+        },
+        Block::Table {
+            id,
+            col_widths,
+            rows,
+            cols,
+            cells,
+        } => CompactBlock::Table {
+            id: id.clone(),
+            col_widths: col_widths
+                .iter()
+                .map(|width| super::round1(*width))
+                .collect(),
+            rows: *rows,
+            cols: *cols,
+            cells: cells.iter().map(compact_cell).collect(),
+        },
+        Block::Image {
+            id,
+            width,
+            height,
+            content_hash,
+            placement,
+        } => CompactBlock::Image {
+            id: id.clone(),
+            width: width.map(super::round1),
+            height: height.map(super::round1),
+            content_hash: content_hash.clone(),
+            placement: placement.as_ref().map(compact_placement),
+        },
+        Block::Textbox {
+            id,
+            placement,
+            blocks,
+        } => CompactBlock::Textbox {
+            id: id.clone(),
+            placement: placement.as_ref().map(compact_placement),
+            blocks: blocks.iter().map(compact_block).collect(),
+        },
+        Block::Break { kind } => CompactBlock::Break { kind: *kind },
+    }
+}
+
+fn compact_cell(cell: &FlowTableCell) -> CompactFlowTableCell {
+    CompactFlowTableCell {
+        row: cell.row,
+        col: cell.col,
+        row_span: cell.row_span,
+        col_span: cell.col_span,
+        content: cell.content.clone(),
+        runs: cell.runs.iter().map(compact_run).collect(),
+        blocks: cell
+            .blocks
+            .as_ref()
+            .map(|blocks| blocks.iter().map(compact_block).collect()),
+    }
+}
+
+fn compact_run(run: &TextRun) -> CompactTextRun {
+    CompactTextRun {
+        content: run.content.clone(),
+        font: compact_font(&run.font),
+        color: compact_color(&run.color),
+        href: run.href.clone(),
+    }
+}
+
+fn compact_placement(placement: &Placement) -> Placement {
+    Placement {
+        frame: placement.frame,
+        x: placement.x.map(super::round1),
+        y: placement.y.map(super::round1),
+        width: placement.width.map(super::round1),
+        height: placement.height.map(super::round1),
+        align_h: placement.align_h.clone(),
+        align_v: placement.align_v.clone(),
+    }
+}
+
+const FLOW_LEGEND: &str = "#legend #section width height | H1..H9/TI/Q/P text | LI level o|b label text | r font size style [href#<uri>] text | TB cols col-width... | c row col rowspan colspan text | I [width height] | BR page|column|section | ~page N | pt, authored flow; no resolved coordinates";
+const HIDDEN_LEGEND: &str =
+    "#legend <hidden> kind [element-id] content | non-visible document context";
+
+impl CompactFlowExtraction {
+    pub fn to_lean(&self) -> String {
+        let mut output = String::new();
+        self.write_lean(&mut output)
+            .expect("writing to a String cannot fail");
+        output
+    }
+
+    pub fn write_lean<W: fmt::Write>(&self, output: &mut W) -> fmt::Result {
+        write!(
+            output,
+            "#docray element v{} sections={}",
+            self.schema_version,
+            self.sections.len()
+        )?;
+        if !self.warnings.is_empty() {
+            write!(output, " warnings={}", self.warnings.len())?;
+        }
+        output.write_char('\n')?;
+        output.write_str(FLOW_LEGEND)?;
+        output.write_char('\n')?;
+        if self
+            .sections
+            .iter()
+            .any(|section| !section.hidden.is_empty())
+        {
+            output.write_str(HIDDEN_LEGEND)?;
+            output.write_char('\n')?;
+        }
+
+        for warning in &self.warnings {
+            writeln!(output, "#warning {}", super::collapse_warning(warning))?;
+        }
+
+        for section in &self.sections {
+            writeln!(
+                output,
+                "#section {} {}",
+                lean_number(section.page_width),
+                lean_number(section.page_height)
+            )?;
+            for story in &section.headers {
+                write_lean_blocks(output, story.blocks())?;
+            }
+            write_lean_blocks(output, &section.blocks)?;
+            for story in &section.footers {
+                write_lean_blocks(output, story.blocks())?;
+            }
+            write_hidden(output, &section.hidden)?;
+        }
+        Ok(())
+    }
+}
+
+fn write_lean_blocks<W: fmt::Write>(output: &mut W, blocks: &[CompactBlock]) -> fmt::Result {
+    for block in blocks {
+        match block {
+            CompactBlock::Paragraph {
+                role,
+                runs,
+                content,
+                list,
+                approx_page,
+                breaks_before,
+                ..
+            } => {
+                for kind in breaks_before {
+                    writeln!(output, "BR {}", break_name(*kind))?;
+                }
+                if let Some(page) = approx_page {
+                    writeln!(output, "~page {page}")?;
+                }
+                if let Some(list) = list {
+                    writeln!(
+                        output,
+                        "LI {} {} {} {}",
+                        list.level,
+                        list_kind_code(list.kind),
+                        escape_text(&list.label),
+                        escape_text(content)
+                    )?;
+                } else {
+                    writeln!(
+                        output,
+                        "{} {}",
+                        paragraph_record(role),
+                        escape_text(content)
+                    )?;
+                }
+                write_lean_runs(output, Some(runs))?;
+            }
+            CompactBlock::Table {
+                col_widths,
+                cols,
+                cells,
+                ..
+            } => {
+                write!(output, "TB {cols}")?;
+                for width in col_widths {
+                    write!(output, " {}", lean_number(*width))?;
+                }
+                output.write_char('\n')?;
+                for cell in cells {
+                    writeln!(
+                        output,
+                        "c {} {} {} {} {}",
+                        cell.row,
+                        cell.col,
+                        cell.row_span,
+                        cell.col_span,
+                        escape_text(&cell.content)
+                    )?;
+                    write_lean_runs(output, Some(&cell.runs))?;
+                    if let Some(blocks) = &cell.blocks {
+                        write_lean_blocks(output, blocks)?;
+                    }
+                }
+            }
+            CompactBlock::Image { width, height, .. } => match (width, height) {
+                (Some(width), Some(height)) => {
+                    writeln!(output, "I {} {}", lean_number(*width), lean_number(*height))?;
+                }
+                _ => output.write_str("I\n")?,
+            },
+            CompactBlock::Textbox { blocks, .. } => write_lean_blocks(output, blocks)?,
+            CompactBlock::Break { kind } => writeln!(output, "BR {}", break_name(*kind))?,
+        }
+    }
+    Ok(())
+}
+
+fn write_hidden<W: fmt::Write>(output: &mut W, hidden: &[HiddenItem]) -> fmt::Result {
+    if hidden.is_empty() {
+        return Ok(());
+    }
+    output.write_str("<hidden>\n")?;
+    for item in hidden {
+        write!(output, "{} ", item.kind)?;
+        if let Some(element) = &item.element {
+            write!(output, "{element} ")?;
+        }
+        writeln!(output, "{}", escape_text(&item.content))?;
+    }
+    output.write_str("</hidden>\n")
+}
+
+fn paragraph_record(role: &str) -> &str {
+    match role {
+        "h1" => "H1",
+        "h2" => "H2",
+        "h3" => "H3",
+        "h4" => "H4",
+        "h5" => "H5",
+        "h6" => "H6",
+        "h7" => "H7",
+        "h8" => "H8",
+        "h9" => "H9",
+        "title" => "TI",
+        "quote" => "Q",
+        _ => "P",
+    }
+}
+
+fn list_kind_code(kind: ListKind) -> &'static str {
+    match kind {
+        ListKind::Ordered => "o",
+        ListKind::Bullet => "b",
+    }
+}
+
+fn break_name(kind: BreakKind) -> &'static str {
+    match kind {
+        BreakKind::Page => "page",
+        BreakKind::Column => "column",
+        BreakKind::Section => "section",
+    }
+}

--- a/crates/docray-model/src/lib.rs
+++ b/crates/docray-model/src/lib.rs
@@ -3,6 +3,10 @@ use std::fmt;
 use std::fmt::Write as _;
 use std::str::FromStr;
 
+mod flow;
+
+pub use flow::*;
+
 pub fn round3(v: f64) -> f64 {
     (v * 1000.0).round() / 1000.0
 }
@@ -316,6 +320,7 @@ impl FromStr for OutputFormat {
 pub enum GranularExtraction<'a> {
     Char(ExplicitCharExtraction<'a>),
     Compact(CompactExtraction),
+    Flow(CompactFlowExtraction),
 }
 
 #[derive(Serialize)]

--- a/crates/docray-model/tests/flow.rs
+++ b/crates/docray-model/tests/flow.rs
@@ -1,0 +1,255 @@
+use docray_model::*;
+
+fn font(size: f64, bold: bool) -> Font {
+    Font {
+        name: "Flow Sans".into(),
+        size,
+        bold,
+        italic: false,
+    }
+}
+
+fn run(content: &str, size: f64, bold: bool, href: Option<&str>) -> TextRun {
+    TextRun {
+        content: content.into(),
+        font: font(size, bold),
+        color: TextColor {
+            fill: Some([0, 0, 0]),
+            stroke: None,
+        },
+        href: href.map(str::to_owned),
+    }
+}
+
+fn paragraph(id: &str, role: &str, content: &str) -> Block {
+    Block::Paragraph {
+        id: id.into(),
+        role: role.into(),
+        runs: vec![],
+        content: content.into(),
+        list: None,
+        placement: None,
+        approx_page: None,
+        breaks_before: vec![],
+    }
+}
+
+fn flow_extraction() -> FlowExtraction {
+    FlowExtraction {
+        schema_version: "1.7".into(),
+        layout: FlowLayout::Flow,
+        source: Source {
+            format: "docx".into(),
+            sha256: "abc".into(),
+            size_bytes: 321,
+        },
+        document: FlowDocumentInfo {
+            metadata: DocMetadata {
+                title: Some("Flow fixture".into()),
+                author: None,
+            },
+        },
+        warnings: vec![],
+        approx_pages: Some(2),
+        sections: vec![Section {
+            page_width: 612.04,
+            page_height: 792.06,
+            margins: Margins {
+                top: 72.04,
+                right: 72.06,
+                bottom: 72.0,
+                left: 72.08,
+            },
+            columns: Some(2),
+            headers: vec![],
+            footers: vec![],
+            blocks: vec![
+                Block::Paragraph {
+                    id: "s0-b0".into(),
+                    role: "h2".into(),
+                    runs: vec![
+                        run("Heading ", 14.04, true, None),
+                        run("text", 14.06, false, Some("https://example.test/h")),
+                    ],
+                    content: "Heading text".into(),
+                    list: None,
+                    placement: Some(Placement {
+                        frame: PlacementFrame::Margin,
+                        x: Some(1.04),
+                        y: None,
+                        width: Some(200.06),
+                        height: None,
+                        align_h: Some("center".into()),
+                        align_v: None,
+                    }),
+                    approx_page: Some(1),
+                    breaks_before: vec![BreakKind::Page],
+                },
+                Block::Paragraph {
+                    id: "s0-b1".into(),
+                    role: "body".into(),
+                    runs: vec![run("Item text", 11.0, false, None)],
+                    content: "Item text".into(),
+                    list: Some(ListInfo {
+                        list_id: "7".into(),
+                        level: 2,
+                        kind: ListKind::Ordered,
+                        label: "1.".into(),
+                    }),
+                    placement: None,
+                    approx_page: Some(1),
+                    breaks_before: vec![],
+                },
+                Block::Table {
+                    id: "s0-b2".into(),
+                    col_widths: vec![100.04, 200.06],
+                    rows: 1,
+                    cols: 2,
+                    cells: vec![FlowTableCell {
+                        row: 0,
+                        col: 0,
+                        row_span: 1,
+                        col_span: 2,
+                        content: "Cell text".into(),
+                        runs: vec![],
+                        blocks: None,
+                    }],
+                },
+                Block::Image {
+                    id: "s0-b3".into(),
+                    width: Some(120.04),
+                    height: Some(60.06),
+                    content_hash: Some("deadbeef".into()),
+                    placement: Some(Placement {
+                        frame: PlacementFrame::Paragraph,
+                        x: None,
+                        y: Some(3.04),
+                        width: Some(120.04),
+                        height: Some(60.06),
+                        align_h: None,
+                        align_v: Some("top".into()),
+                    }),
+                },
+                Block::Textbox {
+                    id: "s0-b4".into(),
+                    placement: Some(Placement {
+                        frame: PlacementFrame::Page,
+                        x: Some(10.04),
+                        y: Some(20.06),
+                        width: Some(30.04),
+                        height: Some(40.06),
+                        align_h: None,
+                        align_v: None,
+                    }),
+                    blocks: vec![paragraph("s0-b4-b0", "quote", "Box text")],
+                },
+                Block::Break {
+                    kind: BreakKind::Section,
+                },
+            ],
+            hidden: vec![HiddenItem {
+                kind: "comment".into(),
+                element: Some("s0-b1".into()),
+                content: "Review this".into(),
+            }],
+        }],
+    }
+}
+
+fn compact_flow(flow: &FlowExtraction) -> CompactFlowExtraction {
+    let Some(GranularExtraction::Flow(compact)) = flow.with_granularity(Granularity::Element)
+    else {
+        panic!("element flow projection must produce compact flow")
+    };
+    compact
+}
+
+#[test]
+fn flow_serialization_has_a_literal_layout_shape_and_roundtrips() {
+    let actual = serde_json::to_string(&flow_extraction()).unwrap();
+    let expected = r#"{"schema_version":"1.7","layout":"flow","source":{"format":"docx","sha256":"abc","size_bytes":321},"document":{"metadata":{"title":"Flow fixture","author":null}},"warnings":[],"approx_pages":2,"sections":[{"page_width":612.04,"page_height":792.06,"margins":{"top":72.04,"right":72.06,"bottom":72.0,"left":72.08},"columns":2,"headers":[],"footers":[],"blocks":[{"type":"paragraph","id":"s0-b0","role":"h2","runs":[{"content":"Heading ","font":{"name":"Flow Sans","size":14.04,"bold":true,"italic":false},"color":{"fill":[0,0,0],"stroke":null}},{"content":"text","font":{"name":"Flow Sans","size":14.06,"bold":false,"italic":false},"color":{"fill":[0,0,0],"stroke":null},"href":"https://example.test/h"}],"content":"Heading text","list":null,"placement":{"frame":"margin","x":1.04,"y":null,"width":200.06,"height":null,"align_h":"center","align_v":null},"approx_page":1,"breaks_before":["page"]},{"type":"paragraph","id":"s0-b1","role":"body","runs":[{"content":"Item text","font":{"name":"Flow Sans","size":11.0,"bold":false,"italic":false},"color":{"fill":[0,0,0],"stroke":null}}],"content":"Item text","list":{"list_id":"7","level":2,"kind":"ordered","label":"1."},"placement":null,"approx_page":1,"breaks_before":[]},{"type":"table","id":"s0-b2","col_widths":[100.04,200.06],"rows":1,"cols":2,"cells":[{"row":0,"col":0,"row_span":1,"col_span":2,"content":"Cell text","runs":[],"blocks":null}]},{"type":"image","id":"s0-b3","width":120.04,"height":60.06,"content_hash":"deadbeef","placement":{"frame":"paragraph","x":null,"y":3.04,"width":120.04,"height":60.06,"align_h":null,"align_v":"top"}},{"type":"textbox","id":"s0-b4","placement":{"frame":"page","x":10.04,"y":20.06,"width":30.04,"height":40.06,"align_h":null,"align_v":null},"blocks":[{"type":"paragraph","id":"s0-b4-b0","role":"quote","runs":[],"content":"Box text","list":null,"placement":null,"approx_page":null,"breaks_before":[]}]},{"type":"break","kind":"section"}],"hidden":[{"kind":"comment","element":"s0-b1","content":"Review this"}]}]}"#;
+    assert_eq!(actual, expected);
+    let decoded: FlowExtraction = serde_json::from_str(expected).unwrap();
+    assert_eq!(decoded, flow_extraction());
+}
+
+#[test]
+fn flow_granularity_is_element_only_and_compacts_authored_numbers() {
+    let flow = flow_extraction();
+    assert!(flow.with_granularity(Granularity::Word).is_none());
+    assert!(flow.with_granularity(Granularity::Char).is_none());
+
+    let value = serde_json::to_value(compact_flow(&flow)).unwrap();
+    assert_eq!(value["schema_version"], "1.7");
+    assert_eq!(value["layout"], "flow");
+    assert_eq!(value["granularity"], "element");
+    assert_eq!(value["sections"][0]["page_width"], 612.0);
+    assert_eq!(value["sections"][0]["page_height"], 792.1);
+    assert_eq!(value["sections"][0]["margins"]["right"], 72.1);
+    assert_eq!(value["sections"][0]["blocks"][0]["placement"]["x"], 1.0);
+    assert_eq!(
+        value["sections"][0]["blocks"][2]["col_widths"],
+        serde_json::json!([100.0, 200.1])
+    );
+}
+
+#[test]
+fn lean_flow_renders_the_exact_flow_grammar() {
+    let actual = compact_flow(&flow_extraction()).to_lean();
+    let expected = concat!(
+        "#docray element v1.7 sections=1\n",
+        "#legend #section width height | H1..H9/TI/Q/P text | LI level o|b label text | r font size style [href#<uri>] text | TB cols col-width... | c row col rowspan colspan text | I [width height] | BR page|column|section | ~page N | pt, authored flow; no resolved coordinates\n",
+        "#legend <hidden> kind [element-id] content | non-visible document context\n",
+        "#section 612 792.1\n",
+        "BR page\n",
+        "~page 1\n",
+        "H2 Heading text\n",
+        "r Flow_Sans 14 b Heading \n",
+        "r Flow_Sans 14.1 - href#<https://example.test/h> text\n",
+        "~page 1\n",
+        "LI 2 o 1. Item text\n",
+        "TB 2 100 200.1\n",
+        "c 0 0 1 2 Cell text\n",
+        "I 120 60.1\n",
+        "Q Box text\n",
+        "BR section\n",
+        "<hidden>\n",
+        "comment s0-b1 Review this\n",
+        "</hidden>\n",
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn hostile_flow_text_cannot_inject_lean_records() {
+    let mut flow = flow_extraction();
+    let blocks = &mut flow.sections[0].blocks;
+    let Block::Paragraph { content, .. } = &mut blocks[0] else {
+        unreachable!()
+    };
+    *content = "heading\nBR page".into();
+    let Block::Paragraph { content, list, .. } = &mut blocks[1] else {
+        unreachable!()
+    };
+    *content = "item\rI 9 9".into();
+    list.as_mut().unwrap().label = "1.\nTB 99".into();
+    let Block::Table { cells, .. } = &mut blocks[2] else {
+        unreachable!()
+    };
+    cells[0].content = "cell\u{2028}</hidden>\nc 9 9 9 9 forged".into();
+
+    let actual = compact_flow(&flow).to_lean();
+    assert!(actual.contains("H2 heading\\nBR page\n"));
+    assert!(actual.contains("LI 2 o 1.\\nTB 99 item\\rI 9 9\n"));
+    assert!(actual.contains("c 0 0 1 2 cell\\u{2028}</hidden>\\nc 9 9 9 9 forged\n"));
+    assert_eq!(actual.lines().filter(|line| *line == "BR page").count(), 1);
+    assert_eq!(
+        actual
+            .lines()
+            .filter(|line| line.starts_with("TB "))
+            .count(),
+        1
+    );
+    assert!(!actual.contains('\r'));
+    assert!(!actual.contains('\u{2028}'));
+}

--- a/crates/docray-model/tests/lean.rs
+++ b/crates/docray-model/tests/lean.rs
@@ -131,6 +131,7 @@ fn extraction() -> Extraction {
 fn lean(extraction: &Extraction, granularity: Granularity) -> String {
     match extraction.with_granularity(granularity) {
         GranularExtraction::Compact(compact) => compact.to_lean(),
+        GranularExtraction::Flow(_) => panic!("paged extraction cannot produce flow output"),
         GranularExtraction::Char(_) => panic!("test only renders compact granularities"),
     }
 }

--- a/crates/docray-pdf/src/extract.rs
+++ b/crates/docray-pdf/src/extract.rs
@@ -6,7 +6,7 @@
 // rather than taking down the service.
 use crate::{bind::pdfium, coords::PageSpace};
 use docray_core::grouping::{group_into_lines, RawChar};
-use docray_core::{sniff_format, Capabilities, ExtractError, Extractor, Format};
+use docray_core::{sniff_format, Capabilities, ExtractError, Extractor, Format, GeometryKind};
 use docray_model::*;
 use pdfium_render::prelude::*;
 use sha2::{Digest, Sha256};
@@ -21,6 +21,7 @@ impl Extractor for PdfExtractor {
     fn capabilities(&self) -> Capabilities {
         Capabilities {
             finest_granularity: Granularity::Char,
+            geometry: GeometryKind::Exact,
         }
     }
 

--- a/crates/docray-pdf/tests/golden.rs
+++ b/crates/docray-pdf/tests/golden.rs
@@ -169,6 +169,7 @@ fn lean_simple_goldens_match_on_linux() {
     ] {
         let lean = match out.with_granularity(level) {
             docray_model::GranularExtraction::Compact(compact) => compact.to_lean(),
+            docray_model::GranularExtraction::Flow(_) => unreachable!(),
             docray_model::GranularExtraction::Char(_) => unreachable!(),
         };
         let golden_path = testdata()

--- a/crates/docray-pdf/tests/text.rs
+++ b/crates/docray-pdf/tests/text.rs
@@ -1,4 +1,4 @@
-use docray_core::{check_granularity, Extractor};
+use docray_core::{check_granularity, Extractor, GeometryKind};
 use docray_model::{Element, Granularity};
 use docray_pdf::PdfExtractor;
 
@@ -101,6 +101,7 @@ fn extracts_text_hierarchy_from_simple_pdf() {
 #[test]
 fn pdf_capabilities_accept_every_granularity() {
     let capabilities = PdfExtractor.capabilities();
+    assert_eq!(capabilities.geometry, GeometryKind::Exact);
     for requested in [
         None,
         Some(Granularity::Char),

--- a/crates/docray-pptx/src/extract.rs
+++ b/crates/docray-pptx/src/extract.rs
@@ -1,4 +1,4 @@
-use docray_core::{Capabilities, ExtractError, Extractor};
+use docray_core::{Capabilities, ExtractError, Extractor, GeometryKind};
 use docray_model::{
     round3, AnnotationElement, BBox, ChartElement, ChartPoint, ChartSeries, DocMetadata,
     DocumentInfo, Element, Extraction, Font, Granularity, HiddenItem, ImageElement, Page,
@@ -22,6 +22,7 @@ impl Extractor for PptxExtractor {
     fn capabilities(&self) -> Capabilities {
         Capabilities {
             finest_granularity: Granularity::Element,
+            geometry: GeometryKind::Container,
         }
     }
 

--- a/crates/docray-pptx/tests/golden.rs
+++ b/crates/docray-pptx/tests/golden.rs
@@ -1,4 +1,4 @@
-use docray_core::{check_granularity, Extractor};
+use docray_core::{check_granularity, Extractor, GeometryKind};
 use docray_model::{Element, GranularExtraction, Granularity, HiddenItem};
 use docray_pptx::PptxExtractor;
 use std::fs;
@@ -32,6 +32,7 @@ fn element_and_lean_goldens_are_byte_exact_on_every_platform() {
             .unwrap();
         let lean = match extraction.with_granularity(Granularity::Element) {
             GranularExtraction::Compact(compact) => compact.to_lean(),
+            GranularExtraction::Flow(_) => unreachable!(),
             GranularExtraction::Char(_) => unreachable!(),
         };
         for (suffix, actual) in [("element.json", json), ("lean.txt", lean)] {
@@ -472,6 +473,7 @@ fn styled_text_fixture_preserves_each_run_style_and_external_href() {
 fn pptx_is_element_only_and_text_has_runs_but_no_lines() {
     let capabilities = PptxExtractor.capabilities();
     assert_eq!(capabilities.finest_granularity, Granularity::Element);
+    assert_eq!(capabilities.geometry, GeometryKind::Container);
     assert!(check_granularity(&capabilities, None).is_err());
     assert!(check_granularity(&capabilities, Some(Granularity::Word)).is_err());
     assert_eq!(

--- a/crates/docray-wasm/src/lib.rs
+++ b/crates/docray-wasm/src/lib.rs
@@ -91,6 +91,16 @@ fn extract_lean_inner(
             })?;
             Ok(w.buf)
         }
+        GranularExtraction::Flow(flow) => {
+            let mut w = CappedString {
+                buf: String::new(),
+                remaining: cap,
+            };
+            flow.write_lean(&mut w).map_err(|_| {
+                WasmError::new(OUTPUT_TOO_LARGE, format!("output exceeded {cap} bytes"))
+            })?;
+            Ok(w.buf)
+        }
         GranularExtraction::Char(_) => unreachable!("char is rejected above"),
     }
 }


### PR DESCRIPTION
Phase 1 of DOCX support — the model layer for honest flow output. **Paged (PDF/PPTX) outputs are byte-identical** (SHA-256 inventory of all 48 goldens unchanged; paged lean writer untouched).

## What
- `FlowExtraction` envelope: `schema_version: "1.7"`, `layout: "flow"`, `sections[]` instead of pages. The paged `Extraction` struct is unchanged (absence of `layout` = paged).
- Sections carry authored page geometry (size/margins/columns from sectPr), variant-tagged header/footer stories, and typed blocks: `paragraph` (role h1–h9/title/quote/body, runs, list info with resolved labels, break markers), `table` (authored col widths, span-aware cells, optional nested blocks), `image`, `textbox` (nested blocks), `break`.
- `Placement` = tagged authored constraint with a reference frame (page/margin/column/paragraph/line) — **never a bbox**; no flow type synthesizes geometry.
- `approx_page`/`approx_pages` fields for provenance-labeled pagination hints.
- `GeometryKind { Exact, Container, Flow }` on Capabilities (PDF=Exact, PPTX=Container); flow sources are element-only via the existing granularity gate.
- Lean flow grammar (v1.7 header): `#section`, `H1..H9/TI/Q/P`, `LI level kind label`, flow `TB`/`c` (no coords), `I`, `BR`, `~page N`; reuses `r` records; all content through the injection-safe escaper; flow legends only in flow output.
- Stable block ids `s{section}-b{index}`; hidden channel targets them unchanged.

## Tests
Literal-JSON pin of a full flow document (all block types + placement + hints), exact lean rendering + injection test, granularity gate with a Flow-geometry stub, and the byte-identity proofs above.

No extractor yet — that's the next phase; this PR is pure model/contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)