### PR TITLE
Make EMF/WMF metafile preview opt-in (default: clean placeholder)

### DIFF
--- a/crates/docray-server/assets/playground.html
+++ b/crates/docray-server/assets/playground.html
@@ -80,6 +80,10 @@
     padding: 5px 10px; cursor: pointer;
   }
   select:focus, .btn:focus { outline: 1px solid var(--amber); outline-offset: 1px; }
+  .metafile-toggle { min-width: 90px; }
+  .metafile-toggle[aria-pressed="true"] {
+    color: var(--amber); border-color: var(--amber-dim); background: rgba(232,163,61,0.09);
+  }
   .btn-amber { background: var(--amber); color: #241a08; border-color: transparent; font-weight: 600; }
   .btn-amber:hover { filter: brightness(1.08); }
   .btn[disabled] { opacity: 0.4; cursor: default; }
@@ -379,6 +383,11 @@
       <option value="word">word — tuples</option>
       <option value="element">element — compact</option>
     </select>
+  </div>
+  <div class="ctl">
+    <label for="metafile-preview">metafile preview</label>
+    <button class="btn metafile-toggle" id="metafile-preview" type="button"
+            aria-pressed="false" title="Approximate client-side EMF/WMF rendering">off</button>
   </div>
   <button class="btn" id="docjson" disabled>document json</button>
   <button class="btn btn-amber" id="pick">upload pdf, pptx, or docx</button>
@@ -46483,6 +46492,7 @@ const state = {
   gen: 0, file: null, fileName: "",
   extraction: null, pdf: null, format: null,
   pageIdx: 0, zoom: 1,
+  renderMetafiles: false,
   filters: new Set(TYPES),
   panelModes: ["source", "boxes"],
   renderCache: new Map(), // "pageNo@zoom@fit" -> {canvas, cssW, cssH, k}
@@ -46542,6 +46552,20 @@ document.addEventListener("drop", e => {
   if (f) load(f);
 });
 $("#gran").onchange = () => { if (state.file) load(state.file, state.pageIdx); };
+$("#metafile-preview").onclick = () => {
+  state.renderMetafiles = !state.renderMetafiles;
+  const toggle = $("#metafile-preview");
+  toggle.setAttribute("aria-pressed", String(state.renderMetafiles));
+  toggle.textContent = state.renderMetafiles ? "approximate" : "off";
+  if (!state.extraction) return;
+  if (state.format === "pptx") {
+    resetPptxLiveThumbs();
+    buildRail(state.gen);
+    goto(state.pageIdx, state.gen);
+  } else if (isFlowExtraction()) {
+    renderPanels(state.gen);
+  }
+};
 
 async function sniffFileFormat(file) {
   const bytes = new Uint8Array(await file.slice(0, 1028).arrayBuffer());
@@ -47143,6 +47167,7 @@ function ensurePptxLiveThumb(index, gen) {
         iframe.contentWindow.postMessage({
           cmd: "render",
           bytes,
+          renderMetafiles: state.renderMetafiles,
           slideIndex: index,
           width: dimensions.width,
           height: dimensions.height,
@@ -47485,6 +47510,7 @@ function pptxIframeMain() {
     if (event.source !== parent || replied || renderStarted) return;
     const data = event.data;
     if (!data || data.cmd !== "render" || !(data.bytes instanceof ArrayBuffer) ||
+        typeof data.renderMetafiles !== "boolean" ||
         !Number.isInteger(data.slideIndex) || data.slideIndex < 0 ||
         !Number.isInteger(data.width) || data.width < 1 ||
         !Number.isInteger(data.height) || data.height < 1) {
@@ -47500,7 +47526,9 @@ function pptxIframeMain() {
     const timer = setTimeout(() => controller.abort(), RENDER_TIMEOUT_MS);
     try {
       const parsed = await _$(data.bytes, fH);
-      const convertedPngPaths = await convertPresentationMetafiles(parsed);
+      const convertedPngPaths = data.renderMetafiles
+        ? await convertPresentationMetafiles(parsed)
+        : new Set();
       const presentation = Ru(parsed, { lazySlides: true });
       if (data.slideIndex >= presentation.slides.length) throw new Error("slide unavailable");
       const viewer = new ay(root, {
@@ -47673,6 +47701,7 @@ function renderPptxSource(panelIndex, body, pageJson, gen, req, pageIndex, fitWi
           iframe.contentWindow.postMessage({
             cmd: "render",
             bytes,
+            renderMetafiles: state.renderMetafiles,
             slideIndex: pageIndex,
             width: dimensions.width,
             height: dimensions.height,
@@ -47787,7 +47816,8 @@ function docxIframeMain() {
   addEventListener("message", async event => {
     if (event.source !== parent || replied || renderStarted) return;
     const data = event.data;
-    if (!data || data.cmd !== "render" || !(data.bytes instanceof ArrayBuffer)) {
+    if (!data || data.cmd !== "render" || !(data.bytes instanceof ArrayBuffer) ||
+        typeof data.renderMetafiles !== "boolean") {
       reply("error");
       return;
     }
@@ -47857,8 +47887,12 @@ function docxIframeMain() {
       };
       const markBrokenImage = async img => {
         if (img.dataset.docrayPlaceholder || img.dataset.docrayMetafilePending) return;
-        img.dataset.docrayMetafilePending = "1";
         const size = imageSize(img);
+        if (!data.renderMetafiles) {
+          showPlaceholder(img, size);
+          return;
+        }
+        img.dataset.docrayMetafilePending = "1";
         try {
           const buffer = decodeBase64DataUrl(img.getAttribute("src") || img.src);
           const kind = sniffWindowsMetafile(buffer);
@@ -48036,7 +48070,11 @@ function renderDocxSource(panelIndex, body, section, gen, req, sectionIndex, fit
         try {
           const bytes = await state.file.arrayBuffer();
           if (!isCurrent() || settled) { cancel(); return; }
-          iframe.contentWindow.postMessage({ cmd: "render", bytes }, "*", [bytes]);
+          iframe.contentWindow.postMessage({
+            cmd: "render",
+            bytes,
+            renderMetafiles: state.renderMetafiles,
+          }, "*", [bytes]);
         } catch (_) {
           fallback();
         }

--- a/crates/docray-server/tests/sync_api.rs
+++ b/crates/docray-server/tests/sync_api.rs
@@ -102,6 +102,7 @@ fn playground_pptx_source_isolation_contract() {
     assert!(html.contains("event.origin !== \"null\""));
     assert!(html.contains("void parent.location.href"));
     assert!(html.contains("parent.postMessage({ status }, \"*\")"));
+    assert!(html.contains("typeof data.renderMetafiles !== \"boolean\""));
     assert!(html.contains("state.file.arrayBuffer()"));
     assert!(html.contains("[bytes]"));
     assert!(html.contains("visual render unavailable - showing structure schematic"));
@@ -129,7 +130,9 @@ fn playground_pptx_metafile_conversion_rewrites_before_build_and_is_bounded() {
     let renderer = &html[start..end];
 
     assert!(renderer.contains("const parsed = await _$(data.bytes, fH);"));
+    assert!(renderer.contains("const convertedPngPaths = data.renderMetafiles"));
     assert!(renderer.contains("await convertPresentationMetafiles(parsed)"));
+    assert!(renderer.contains(": new Set();"));
     assert!(renderer.contains("const presentation = Ru(parsed, { lazySlides: true });"));
     assert!(renderer.contains("const viewer = new ay(root"));
     assert!(renderer.contains("viewer.load(presentation);"));
@@ -163,8 +166,8 @@ fn playground_docx_source_isolation_contract() {
     assert!(html.contains("void parent.location.href"));
     assert!(html.contains("keys.length !== 1 || keys[0] !== \"status\""));
     assert!(html.contains("parent.postMessage({ status }, \"*\")"));
-    assert!(html
-        .contains("iframe.contentWindow.postMessage({ cmd: \"render\", bytes }, \"*\", [bytes])"));
+    assert!(html.contains("typeof data.renderMetafiles !== \"boolean\""));
+    assert!(html.contains("renderMetafiles: state.renderMetafiles"));
     assert!(html.contains("visual render unavailable - showing reading-order schematic"));
     assert!(html.contains("flow content has no resolved boxes"));
     assert!(html.contains("READING ORDER - synthetic layout, not positions"));
@@ -207,11 +210,47 @@ fn playground_docx_metafile_conversion_is_honest_and_bounded() {
     assert!(!renderer.contains("maxRecords:"));
     assert!(!renderer.contains("maxCanvasDimension:"));
     assert!(renderer.contains("if (!rendered)"));
+    let opt_in_guard = renderer.find("if (!data.renderMetafiles)").unwrap();
+    let sniff_call = renderer
+        .find("const kind = sniffWindowsMetafile(buffer);")
+        .unwrap();
+    assert!(opt_in_guard < sniff_call);
     assert!(renderer.contains("showPlaceholder(img, size);"));
     assert!(renderer.contains("image not previewable in browser"));
     assert!(renderer.contains("marker.textContent = \"≈\""));
     assert!(renderer.contains("marker.title = \"approximate render — Windows metafile (EMF/WMF)\""));
     assert!(renderer.contains("marker.setAttribute(\"aria-label\", marker.title)"));
+}
+
+#[test]
+fn playground_metafile_preview_is_single_default_off_toggle() {
+    let html = include_str!("../assets/playground.html");
+
+    assert_eq!(html.matches("id=\"metafile-preview\"").count(), 1);
+    assert!(html.contains(
+        "aria-pressed=\"false\" title=\"Approximate client-side EMF/WMF rendering\">off</button>"
+    ));
+    assert!(html.contains("renderMetafiles: false,"));
+    assert!(html.contains("state.renderMetafiles = !state.renderMetafiles;"));
+    assert!(
+        html.contains("toggle.textContent = state.renderMetafiles ? \"approximate\" : \"off\";")
+    );
+    assert!(html.contains("resetPptxLiveThumbs();"));
+    assert!(html.contains("goto(state.pageIdx, state.gen);"));
+    assert!(html.contains("renderPanels(state.gen);"));
+
+    // PPTX source, PPTX live thumbnails, and DOCX source all receive the same
+    // explicit default-off state. The two iframe programs reject non-booleans.
+    assert_eq!(
+        html.matches("renderMetafiles: state.renderMetafiles")
+            .count(),
+        3
+    );
+    assert_eq!(
+        html.matches("typeof data.renderMetafiles !== \"boolean\"")
+            .count(),
+        2
+    );
 }
 
 #[test]


### PR DESCRIPTION
Client-side EMF/WMF rendering nails the common Excel-paste case but garbles some real files, and we can't detect a bad render at runtime (confirmed: two independent renderers — the JS lib and the Rust emfsdk crate — both garble the same file; simple dark-pixel/row heuristics don't separate good from bad). A garbled render looks like corrupt data — worse than an honest placeholder — so it shouldn't be the default.

## Change
A single default-OFF playground toggle ("metafile preview: off/approximate") gates client-side EMF/WMF rendering in both the DOCX and PPTX sandbox previews:
- **Off (default):** failed image decodes show the clean "image not previewable in browser" placeholder (docx) / the renderer's own unsupported-format placeholder (pptx). Never a garble by default.
- **On:** the approximate render + `≈` marker (great for the common case — LASSO/Pureinfluencer financial tables render pixel-faithfully).

The flag rides the existing render-command message into both iframes; toggling re-renders via the existing generation-token machinery.

## Isolation
Unchanged: sandbox="allow-scripts", exact CSP (no token added), status-only postMessage, null-origin, no parent DOM reads. All four vendored blob sha256 pins intact. Headless Chrome confirmed off→placeholder, on→marked PNG.

## Contract
Playground-only; no extraction/model/CLI change; frozen goldens byte-identical; wasm parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)