### PR TITLE
Show the metafile-preview toggle only when the document has EMF/WMF

### DIFF
--- a/crates/docray-server/assets/playground.html
+++ b/crates/docray-server/assets/playground.html
@@ -384,7 +384,7 @@
       <option value="element">element — compact</option>
     </select>
   </div>
-  <div class="ctl">
+  <div class="ctl" id="metafile-preview-ctl" style="display:none">
     <label for="metafile-preview">metafile preview</label>
     <button class="btn metafile-toggle" id="metafile-preview" type="button"
             aria-pressed="false" title="Approximate client-side EMF/WMF rendering">off</button>
@@ -46493,6 +46493,7 @@ const state = {
   extraction: null, pdf: null, format: null,
   pageIdx: 0, zoom: 1,
   renderMetafiles: false,
+  hasMetafiles: false,
   filters: new Set(TYPES),
   panelModes: ["source", "boxes"],
   renderCache: new Map(), // "pageNo@zoom@fit" -> {canvas, cssW, cssH, k}
@@ -46541,7 +46542,7 @@ $("#drop").onclick = () => $("#file").click();
 $("#file").onchange = e => {
   const f = e.target.files[0];
   e.target.value = ""; // allow re-selecting the same file after a failure
-  if (f) load(f);
+  if (f) load(f, undefined, true);
 };
 ["dragover", "dragenter"].forEach(ev =>
   document.addEventListener(ev, e => { e.preventDefault(); $("#drop").classList.add("armed"); }));
@@ -46549,7 +46550,7 @@ $("#file").onchange = e => {
   document.addEventListener(ev, e => { e.preventDefault(); $("#drop").classList.remove("armed"); }));
 document.addEventListener("drop", e => {
   const f = e.dataTransfer && e.dataTransfer.files[0];
-  if (f) load(f);
+  if (f) load(f, undefined, true);
 });
 $("#gran").onchange = () => { if (state.file) load(state.file, state.pageIdx); };
 $("#metafile-preview").onclick = () => {
@@ -46566,6 +46567,27 @@ $("#metafile-preview").onclick = () => {
     renderPanels(state.gen);
   }
 };
+
+function setMetafilePreviewVisible(visible) {
+  $("#metafile-preview-ctl").style.display = visible ? "" : "none";
+}
+
+function updateMetafileAvailability(gen, available) {
+  if (gen !== state.gen || typeof available !== "boolean") return;
+  state.hasMetafiles = available;
+  setMetafilePreviewVisible(available);
+}
+
+function isBoundedRendererStatus(data) {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return false;
+  const keys = Object.keys(data);
+  if (keys.length < 1 || keys.some(key =>
+    key !== "status" && key !== "message" && key !== "metafiles")) return false;
+  return ["ready", "rendered", "error"].includes(data.status) &&
+    (data.message === undefined ||
+      (typeof data.message === "string" && data.message.length <= 160)) &&
+    (data.metafiles === undefined || typeof data.metafiles === "boolean");
+}
 
 async function sniffFileFormat(file) {
   const bytes = new Uint8Array(await file.slice(0, 1028).arrayBuffer());
@@ -46760,8 +46782,10 @@ const enginesReady = probeEngines();
 
 let inflight = null;
 
-async function load(file, keepPageIdx) {
+async function load(file, keepPageIdx, newUpload = false) {
   const gen = ++state.gen;
+  const replacesDocument = newUpload || file !== state.file;
+  if (newUpload) setMetafilePreviewVisible(false);
   // A generation owns every hostile-deck iframe. Tear live thumbnails down
   // immediately, even if this upload later fails and the retained document is
   // rebuilt, so no old frame can outlive an upload or engine switch.
@@ -46850,6 +46874,10 @@ async function load(file, keepPageIdx) {
   state.leanCache = {}; // canonical lean bytes, keyed by granularity
   state.pdf = pdf;
   state.format = format;
+  if (replacesDocument) {
+    state.hasMetafiles = false;
+    setMetafilePreviewVisible(false);
+  }
   const viewCount = flow ? extraction.sections.length : extraction.pages.length;
   state.pageIdx = Math.min(keepPageIdx || 0, Math.max(viewCount - 1, 0));
   state.zoom = 1;
@@ -46897,6 +46925,7 @@ function fmtBytes(n) {
 function restoreRetainedDocument(gen) {
   if (!state.extraction || (!state.pdf && state.format !== "pptx" && !isFlowExtraction()) ||
       gen !== state.gen) return;
+  setMetafilePreviewVisible(state.hasMetafiles);
   buildRail(gen);
   goto(state.pageIdx, gen);
 }
@@ -47153,10 +47182,7 @@ function ensurePptxLiveThumb(index, gen) {
   entry.onMessage = async event => {
     if (event.source !== iframe.contentWindow || event.origin !== "null" || entry.closed) return;
     const data = event.data;
-    if (!data || typeof data !== "object" || Array.isArray(data)) return;
-    const keys = Object.keys(data);
-    if (keys.length !== 1 || keys[0] !== "status" ||
-        !["ready", "rendered", "error"].includes(data.status)) return;
+    if (!isBoundedRendererStatus(data)) return;
     if (data.status === "ready") {
       if (entry.ready || entry.bytesPosted) return;
       entry.ready = true;
@@ -47176,6 +47202,7 @@ function ensurePptxLiveThumb(index, gen) {
         failPptxLiveThumb(entry, false);
       }
     } else if (data.status === "rendered") {
+      updateMetafileAvailability(gen, data.metafiles);
       entry.rendered = true;
       clearTimeout(entry.timer);
       removeEventListener("message", entry.onMessage);
@@ -47295,10 +47322,10 @@ function pptxIframeMain() {
   let replied = false;
   let renderStarted = false;
 
-  function reply(status) {
+  function reply(status, metafiles) {
     if (replied && status !== "error") return;
     if (status === "rendered" || status === "error") replied = true;
-    parent.postMessage({ status }, "*");
+    parent.postMessage(metafiles === undefined ? { status } : { status, metafiles }, "*");
   }
 
   // A correctly sandboxed srcdoc has an opaque/null origin. If this probe can
@@ -47526,6 +47553,8 @@ function pptxIframeMain() {
     const timer = setTimeout(() => controller.abort(), RENDER_TIMEOUT_MS);
     try {
       const parsed = await _$(data.bytes, fH);
+      const metafiles = [...parsed.media.keys()].some(path =>
+        /^ppt\/media\/.*\.(?:emf|wmf)$/i.test(normalizePackagePath(path)));
       const convertedPngPaths = data.renderMetafiles
         ? await convertPresentationMetafiles(parsed)
         : new Set();
@@ -47543,7 +47572,7 @@ function pptxIframeMain() {
         markApproximateMetafileRender(root);
       }
       clearTimeout(timer);
-      reply("rendered");
+      reply("rendered", metafiles);
     } catch (_) {
       clearTimeout(timer);
       reply("error");
@@ -47686,12 +47715,7 @@ function renderPptxSource(panelIndex, body, pageJson, gen, req, pageIndex, fitWi
     const onMessage = async event => {
       if (event.source !== iframe.contentWindow || event.origin !== "null" || settled) return;
       const data = event.data;
-      if (!data || typeof data !== "object" || Array.isArray(data)) return;
-      const keys = Object.keys(data);
-      if (keys.some(key => key !== "status" && key !== "message") ||
-          typeof data.status !== "string" ||
-          (data.message !== undefined &&
-            (typeof data.message !== "string" || data.message.length > 160))) return;
+      if (!isBoundedRendererStatus(data)) return;
       if (data.status === "ready") {
         if (bytesPosted) return;
         bytesPosted = true;
@@ -47710,6 +47734,7 @@ function renderPptxSource(panelIndex, body, pageJson, gen, req, pageIndex, fitWi
           fallback();
         }
       } else if (data.status === "rendered") {
+        updateMetafileAvailability(gen, data.metafiles);
         if (isCurrent()) loading.remove();
         finish();
       } else if (data.status === "error") {
@@ -47739,10 +47764,10 @@ function docxIframeMain() {
   let replied = false;
   let renderStarted = false;
 
-  function reply(status) {
+  function reply(status, metafiles) {
     if (replied && status !== "error") return;
     if (status === "rendered" || status === "error") replied = true;
-    parent.postMessage({ status }, "*");
+    parent.postMessage(metafiles === undefined ? { status } : { status, metafiles }, "*");
   }
 
   // A correctly sandboxed srcdoc has an opaque/null origin. If this probe can
@@ -47885,17 +47910,19 @@ function docxIframeMain() {
         box.textContent = "image not previewable in browser";
         img.replaceWith(box);
       };
+      let metafiles = false;
       const markBrokenImage = async img => {
         if (img.dataset.docrayPlaceholder || img.dataset.docrayMetafilePending) return;
         const size = imageSize(img);
-        if (!data.renderMetafiles) {
-          showPlaceholder(img, size);
-          return;
-        }
-        img.dataset.docrayMetafilePending = "1";
         try {
           const buffer = decodeBase64DataUrl(img.getAttribute("src") || img.src);
           const kind = sniffWindowsMetafile(buffer);
+          if (kind) metafiles = true;
+          if (!data.renderMetafiles || !kind) {
+            showPlaceholder(img, size);
+            return;
+          }
+          img.dataset.docrayMetafilePending = "1";
           let rendered = null;
           if (kind === "emf") {
             rendered = await globalThis.EMFC.convertEmfToDataUrl(buffer, { dpiScale: 2 });
@@ -47928,6 +47955,8 @@ function docxIframeMain() {
       };
       const immediateConversions = [];
       for (const img of document.querySelectorAll("img")) {
+        const buffer = decodeBase64DataUrl(img.getAttribute("src") || img.src);
+        if (sniffWindowsMetafile(buffer)) metafiles = true;
         if (img.complete && img.naturalWidth === 0) immediateConversions.push(markBrokenImage(img));
         else if (!img.complete) {
           img.addEventListener("error", () => { void markBrokenImage(img); }, { once: true });
@@ -47935,7 +47964,7 @@ function docxIframeMain() {
       }
       await Promise.all(immediateConversions);
       clearTimeout(timer);
-      if (!replied) reply("rendered");
+      if (!replied) reply("rendered", metafiles);
     } catch (_) {
       clearTimeout(timer);
       reply("error");
@@ -48060,10 +48089,7 @@ function renderDocxSource(panelIndex, body, section, gen, req, sectionIndex, fit
     const onMessage = async event => {
       if (event.source !== iframe.contentWindow || event.origin !== "null" || settled) return;
       const data = event.data;
-      if (!data || typeof data !== "object" || Array.isArray(data)) return;
-      const keys = Object.keys(data);
-      if (keys.length !== 1 || keys[0] !== "status" ||
-          !["ready", "rendered", "error"].includes(data.status)) return;
+      if (!isBoundedRendererStatus(data)) return;
       if (data.status === "ready") {
         if (bytesPosted) return;
         bytesPosted = true;
@@ -48079,6 +48105,7 @@ function renderDocxSource(panelIndex, body, section, gen, req, sectionIndex, fit
           fallback();
         }
       } else if (data.status === "rendered") {
+        updateMetafileAvailability(gen, data.metafiles);
         if (isCurrent()) loading.remove();
         finish();
       } else {

--- a/crates/docray-server/tests/sync_api.rs
+++ b/crates/docray-server/tests/sync_api.rs
@@ -101,7 +101,9 @@ fn playground_pptx_source_isolation_contract() {
     ));
     assert!(html.contains("event.origin !== \"null\""));
     assert!(html.contains("void parent.location.href"));
-    assert!(html.contains("parent.postMessage({ status }, \"*\")"));
+    assert!(html.contains(
+        "parent.postMessage(metafiles === undefined ? { status } : { status, metafiles }, \"*\")"
+    ));
     assert!(html.contains("typeof data.renderMetafiles !== \"boolean\""));
     assert!(html.contains("state.file.arrayBuffer()"));
     assert!(html.contains("[bytes]"));
@@ -130,6 +132,10 @@ fn playground_pptx_metafile_conversion_rewrites_before_build_and_is_bounded() {
     let renderer = &html[start..end];
 
     assert!(renderer.contains("const parsed = await _$(data.bytes, fH);"));
+    assert!(renderer.contains("const metafiles = [...parsed.media.keys()].some(path =>"));
+    assert!(
+        renderer.contains("/^ppt\\/media\\/.*\\.(?:emf|wmf)$/i.test(normalizePackagePath(path))")
+    );
     assert!(renderer.contains("const convertedPngPaths = data.renderMetafiles"));
     assert!(renderer.contains("await convertPresentationMetafiles(parsed)"));
     assert!(renderer.contains(": new Set();"));
@@ -151,6 +157,7 @@ fn playground_pptx_metafile_conversion_rewrites_before_build_and_is_bounded() {
     assert!(renderer.contains("marker.textContent = \"≈\""));
     assert!(renderer.contains("marker.title = \"approximate render — Windows metafile (EMF/WMF)\""));
     assert!(renderer.contains("viewer.mediaUrlCache.has(path)"));
+    assert!(renderer.contains("reply(\"rendered\", metafiles);"));
 }
 
 #[test]
@@ -164,8 +171,9 @@ fn playground_docx_source_isolation_contract() {
     ));
     assert!(html.contains("event.source !== iframe.contentWindow || event.origin !== \"null\""));
     assert!(html.contains("void parent.location.href"));
-    assert!(html.contains("keys.length !== 1 || keys[0] !== \"status\""));
-    assert!(html.contains("parent.postMessage({ status }, \"*\")"));
+    assert!(html.contains(
+        "parent.postMessage(metafiles === undefined ? { status } : { status, metafiles }, \"*\")"
+    ));
     assert!(html.contains("typeof data.renderMetafiles !== \"boolean\""));
     assert!(html.contains("renderMetafiles: state.renderMetafiles"));
     assert!(html.contains("visual render unavailable - showing reading-order schematic"));
@@ -210,11 +218,16 @@ fn playground_docx_metafile_conversion_is_honest_and_bounded() {
     assert!(!renderer.contains("maxRecords:"));
     assert!(!renderer.contains("maxCanvasDimension:"));
     assert!(renderer.contains("if (!rendered)"));
-    let opt_in_guard = renderer.find("if (!data.renderMetafiles)").unwrap();
     let sniff_call = renderer
         .find("const kind = sniffWindowsMetafile(buffer);")
         .unwrap();
-    assert!(opt_in_guard < sniff_call);
+    let opt_in_guard = renderer
+        .find("if (!data.renderMetafiles || !kind)")
+        .unwrap();
+    assert!(sniff_call < opt_in_guard);
+    assert!(renderer.contains("if (kind) metafiles = true;"));
+    assert!(renderer.contains("if (sniffWindowsMetafile(buffer)) metafiles = true;"));
+    assert!(renderer.contains("reply(\"rendered\", metafiles);"));
     assert!(renderer.contains("showPlaceholder(img, size);"));
     assert!(renderer.contains("image not previewable in browser"));
     assert!(renderer.contains("marker.textContent = \"≈\""));
@@ -227,6 +240,8 @@ fn playground_metafile_preview_is_single_default_off_toggle() {
     let html = include_str!("../assets/playground.html");
 
     assert_eq!(html.matches("id=\"metafile-preview\"").count(), 1);
+    assert_eq!(html.matches("id=\"metafile-preview-ctl\"").count(), 1);
+    assert!(html.contains("<div class=\"ctl\" id=\"metafile-preview-ctl\" style=\"display:none\">"));
     assert!(html.contains(
         "aria-pressed=\"false\" title=\"Approximate client-side EMF/WMF rendering\">off</button>"
     ));
@@ -238,6 +253,14 @@ fn playground_metafile_preview_is_single_default_off_toggle() {
     assert!(html.contains("resetPptxLiveThumbs();"));
     assert!(html.contains("goto(state.pageIdx, state.gen);"));
     assert!(html.contains("renderPanels(state.gen);"));
+    assert!(html.contains("if (newUpload) setMetafilePreviewVisible(false);"));
+    assert!(html.contains("setMetafilePreviewVisible(state.hasMetafiles);"));
+    assert!(html.contains("state.hasMetafiles = available;"));
+    assert_eq!(
+        html.matches("updateMetafileAvailability(gen, data.metafiles);")
+            .count(),
+        3
+    );
 
     // PPTX source, PPTX live thumbnails, and DOCX source all receive the same
     // explicit default-off state. The two iframe programs reject non-booleans.
@@ -251,6 +274,38 @@ fn playground_metafile_preview_is_single_default_off_toggle() {
             .count(),
         2
     );
+}
+
+#[test]
+fn playground_renderer_status_reply_is_bounded_and_typed() {
+    let html = include_str!("../assets/playground.html");
+
+    // The shared validator accepts {status}, {status,message}, and
+    // {status,metafiles:boolean}; every other key and non-boolean metafiles
+    // are rejected. All three parent receivers use this one contract.
+    assert!(html.contains("function isBoundedRendererStatus(data) {"));
+    assert!(html.contains("if (keys.length < 1 || keys.some(key =>"));
+    assert!(html.contains("key !== \"status\" && key !== \"message\" && key !== \"metafiles\""));
+    assert!(html.contains("[\"ready\", \"rendered\", \"error\"].includes(data.status)"));
+    assert!(html.contains("typeof data.message === \"string\" && data.message.length <= 160"));
+    assert!(html.contains("data.metafiles === undefined || typeof data.metafiles === \"boolean\""));
+    assert_eq!(
+        html.matches("if (!isBoundedRendererStatus(data)) return;")
+            .count(),
+        3
+    );
+
+    // ready/error stay one-key replies; only rendered supplies the optional
+    // bounded boolean, and both iframe programs use the same reply shape.
+    assert_eq!(
+        html.matches(
+            "parent.postMessage(metafiles === undefined ? { status } : { status, metafiles }, \"*\")"
+        )
+        .count(),
+        2
+    );
+    assert_eq!(html.matches("reply(\"ready\");").count(), 2);
+    assert_eq!(html.matches("reply(\"rendered\", metafiles);").count(), 2);
 }
 
 #[test]
@@ -269,9 +324,10 @@ fn playground_pptx_thumbnail_isolation_contract() {
     ));
     assert!(html.contains("iframe.srcdoc = pptxRendererSrcdoc();"));
     assert!(html.contains("event.source !== iframe.contentWindow || event.origin !== \"null\""));
-    assert!(html.contains("keys.length !== 1 || keys[0] !== \"status\""));
-    assert!(html.contains("![\"ready\", \"rendered\", \"error\"].includes(data.status)"));
-    assert!(html.contains("parent.postMessage({ status }, \"*\")"));
+    assert!(html.contains("if (!isBoundedRendererStatus(data)) return;"));
+    assert!(html.contains(
+        "parent.postMessage(metafiles === undefined ? { status } : { status, metafiles }, \"*\")"
+    ));
     assert!(!html.contains("PPTX_THUMB_DATA_URL_MAX"));
     assert!(!html.contains("cmd: \"renderThumb\""));
     assert!(!thumbnail_code.contains("dataUrl"));


### PR DESCRIPTION
The "metafile preview" toggle showed for every document, including PDFs — confusing, since only DOCX/PPTX can contain Windows metafiles. Now it appears only when the loaded document actually has EMF/WMF.

## How
Detection comes from the sandbox iframe (which parses the media), not the parent — the parent never parses uploaded bytes. The child→parent status reply gains one bounded optional field `metafiles: boolean`:
- **pptx**: enumerates `ppt/media/*.emf|*.wmf` names (no conversion needed, works with the toggle off).
- **docx**: sniffs each failed-decode image before the opt-in guard, so presence is detected even when rendering is off.
- **PDF**: never reports it → toggle stays hidden.

The parent hides the control by default, reveals it only on a `metafiles:true` report for the current generation token (stale renders can't reveal it), and re-hides on every new upload. The on/off state persists; only visibility is gated.

## Isolation
The reply validator now accepts keys ⊆ `{status, message, metafiles}` and rejects unknown keys / non-boolean `metafiles` / over-long messages — pinned by a new test. sandbox/CSP/one-transferable-ArrayBuffer unchanged; all four vendored blob sha256 pins intact.

## Contract
Playground-only; no extraction/model/CLI change; frozen goldens byte-identical; wasm parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)