### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "docray-cli"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "docray-core"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "docray-model",
  "serde",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "docray-docx"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "docray-model"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "docray-ooxml"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "docray-core",
  "quick-xml",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pdf"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pptx"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "docray-server"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "axum",
  "docray-model",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "docray-wasm"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "docray-core",
  "docray-docx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "0.3.1"
+version = "0.4.0"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Version bump 0.3.1 → 0.4.0.

## Highlights since v0.3.1
- **Native DOCX/DOCM extraction** — honest flow layout (schema 1.7): sections and blocks with resolved heading roles, list labels, tables (incl. nested), images, hyperlinks, and a hidden channel (comments, tracked changes, field instructions, footnotes/endnotes). No fabricated coordinates; page hints carry provenance. Available across CLI, server, and WASM. Real-file verified (zero unaccounted characters) and adversarially reviewed.
- **DOCX playground** — sandboxed docx-preview SOURCE pane (null-origin iframe), section-based navigation, and an honest lens contract: BOXES shows only genuinely positioned containers with a clear note; X-RAY is a labeled reading-order schematic; extraction geometry is never overlaid on the render.
- **EMF/WMF preview rendering** — Windows vector metafiles (common Excel-paste charts/tables) render in the DOCX and PPTX previews via a vendored, sandboxed converter. Opt-in and approximate-labeled (some files can't be rendered faithfully by any lightweight engine), and the toggle appears only when a document actually contains metafiles.

Frozen PDF (schema 1.1) and PPTX (1.6) outputs are byte-identical throughout. This is a clean version bump; all format/contract docs landed with their feature PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)