### PR TITLE
[codex] Add Markdown output

### DIFF
--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -6,8 +6,8 @@ docray extract <FILE> [OPTIONS]
 Options:
   --granularity <element|word|char>  Output detail. Omit for byte-identical
                                      lossless (schema 1.1) output.
-  --format <json|lean>               Output encoding. Default: json. Lean
-                                     implies element granularity.
+  --format <json|lean|md>            Output encoding. Default: json. Lean and
+                                     Markdown imply element granularity.
   --max-pages <N>                    Refuse documents over the page/flow cap.
   --pretty                           Pretty-print the JSON.
 ```
@@ -28,13 +28,13 @@ with a stable exit code:
 
 | Exit | Code | Meaning |
 |---:|---|---|
-| 0 | — | success (warnings, if any, are inside the JSON / `#warning` lines in lean) |
+| 0 | — | success (warnings are inside JSON, `#warning` lean lines, or Markdown callouts) |
 | 2 | `unsupported_format` | input is not supported PDF/PPTX/DOCX/DOCM, or is legacy/encrypted Office |
 | 3 | `encrypted_pdf` | password-protected |
 | 4 | `parse_failure` | document could not be opened |
 | 5 | `io_error` | file unreadable / missing |
 | 6 | `too_many_pages` | over the `--max-pages` cap |
-| 7 | `bad_format` | invalid format, or lean requested with `char` granularity |
+| 7 | `bad_format` | invalid format, or lean/Markdown requested with `char` granularity |
 | 8 | `granularity_unavailable` | the requested granularity is finer than this source provides |
 
 Anything else (e.g. 101, or death by signal) means the parser crashed —
@@ -62,6 +62,9 @@ docray extract input.pdf | jq -e '.warnings | length == 0'
 
 # Token-lean element output for an LLM
 docray extract report.pdf --format lean
+
+# Reading-order Markdown with inferred PDF headings
+docray extract report.pdf --format md
 ```
 
 `--format lean --granularity word` emits word boxes. Lean with no explicit
@@ -70,12 +73,16 @@ exit 7 and code `bad_format`. `--pretty` affects JSON only. See
 [output formats](output-formats.md) for the line format and its deliberate
 lossless-JSON deltas.
 
+`--format md` follows the same granularity defaults and `char` rejection.
+Markdown emits semantic prose rather than coordinate detail; `element` is the
+recommended setting.
+
 PPTX supports element granularity. An omitted `--granularity` defaults to
 `element` for PPTX (so `docray extract deck.pptx` just works), and lean also
 defaults to element; asking for finer detail (`word` or `char`) returns exit 8
 with `granularity_unavailable`. See [PowerPoint extraction](pptx.md).
 
-DOCX and DOCM also default to element and support lean. They emit schema 1.7
+DOCX and DOCM also default to element and support lean and Markdown. They emit schema 1.7
 flow sections/blocks; `word` and `char` return exit 8. With pagination hints,
 `--max-pages` caps the approximate page count. Without hints it caps blocks at
 `N * 200` and records the approximation warning. See [Word extraction](docx.md).

--- a/book/src/docx.md
+++ b/book/src/docx.md
@@ -19,6 +19,7 @@ DOCX is element-only and defaults to that finest level:
 ```bash
 docray extract report.docx
 docray extract report.docx --format lean
+docray extract report.docx --format md
 ```
 
 `word` and `char` return `granularity_unavailable`. DOCM is parsed identically,

--- a/book/src/granularity.md
+++ b/book/src/granularity.md
@@ -5,8 +5,9 @@ make as a consumer** — it changes payload size by more than an order of
 magnitude.
 
 > **The short version: if an LLM reads the output, use `element`, then select
-> the token-lean [`lean` output format](output-formats.md) when you do not need
-> the JSON provenance envelope.** It carries the text, position, and style of
+> the token-lean [`lean` output format](output-formats.md) when you need
+> positions, or `md` when you need clean reading-order prose and do not need
+> the JSON provenance envelope.** Element JSON carries text, position, and style of
 > every element at ~7% of the lossless payload. Only move to `word` when you
 > need word-level highlighting, and to `char` when you need the full archival
 > hierarchy.

--- a/book/src/http-api.md
+++ b/book/src/http-api.md
@@ -1,7 +1,7 @@
 # HTTP API
 
 Endpoints accept PDF, PPTX, DOCX, or DOCM multipart uploads and return JSON by default. Successful lean
-extractions return UTF-8 text; every error — at any layer — still uses the
+and Markdown extractions return UTF-8 text; every error — at any layer — still uses the
 same JSON envelope:
 
 ```json
@@ -11,12 +11,13 @@ same JSON envelope:
 ## Sync extraction
 
 ```text
-POST /v1/extract[?granularity=element|word|char][&format=json|lean]
+POST /v1/extract[?granularity=element|word|char][&format=json|lean|md]
 Content-Type: multipart/form-data   (field name: file)
 ```
 
 Returns `200` with extraction JSON, or `text/plain; charset=utf-8` for lean.
-Lean with no granularity implies `element`; lean with `char` returns
+Markdown uses `text/markdown; charset=utf-8`. Lean and Markdown with no
+granularity imply `element`; either with `char` returns
 `400 bad_format`. The endpoint is bounded for interactive use: **25 MB / 200
 pages** by default (configurable). Oversized requests get `413` pointing you
 to the jobs API.
@@ -26,6 +27,7 @@ curl -sf -F file=@report.pdf 'http://localhost:41619/v1/extract?granularity=elem
 # PPTX and DOCX default to element granularity
 curl -sf -F file=@deck.pptx 'http://localhost:41619/v1/extract?granularity=element'
 curl -sf -F file=@report.docx 'http://localhost:41619/v1/extract'
+curl -sf -F file=@report.pdf 'http://localhost:41619/v1/extract?format=md'
 ```
 
 ## Async jobs
@@ -33,17 +35,17 @@ curl -sf -F file=@report.docx 'http://localhost:41619/v1/extract'
 For large documents (default cap 1 GiB):
 
 ```text
-POST /v1/jobs[?granularity=…][&format=json|lean] → 202 {"job_id": "…"}
+POST /v1/jobs[?granularity=…][&format=json|lean|md] → 202 {"job_id": "…"}
 GET  /v1/jobs/{id}                → {"job_id", "status", "error"}
-GET  /v1/jobs/{id}/result         → 200 stored JSON or lean bytes
+GET  /v1/jobs/{id}/result         → 200 stored JSON, lean, or Markdown bytes
 ```
 
 `status` walks `queued → running → succeeded | failed`. The result endpoint
 returns `404` with code `not_ready` until the job succeeds and `not_found`
 for unknown ids. Jobs and results are retained for 24 h (configurable), then
 swept. The requested format is persisted on the job, and the result endpoint
-uses it to return `application/json` or `text/plain; charset=utf-8`. Job state
-is instance-local — see
+uses it to return the corresponding JSON, lean, or Markdown content type. Job
+state is instance-local — see
 [architecture & guarantees](architecture.md).
 
 ## Error code map
@@ -51,7 +53,7 @@ is instance-local — see
 | HTTP | Code | Meaning |
 |---:|---|---|
 | 400 | `bad_granularity` | invalid `granularity` value |
-| 400 | `bad_format` | invalid `format`, or lean combined with `char` |
+| 400 | `bad_format` | invalid `format`, or lean/Markdown combined with `char` |
 | 400 | `granularity_unavailable` | the requested granularity is finer than this source provides |
 | 400 | `bad_multipart` / `missing_file` | malformed upload |
 | 413 | `too_large` / `too_many_pages` | over sync caps — use jobs |

--- a/book/src/output-formats.md
+++ b/book/src/output-formats.md
@@ -1,14 +1,17 @@
 # Output formats
 
-docray has two output encodings: `json`, the default machine contract, and
-`lean`, a line-oriented reading format for token-conscious LLM consumers.
-Choose granularity separately: lean supports `element` and `word`; requesting
-lean without a granularity implies `element`.
+docray has three output encodings: `json`, the default machine contract;
+`lean`, a line-oriented reading format for token-conscious LLM consumers; and
+`md`, deterministic GitHub-flavored Markdown for human review and semantic
+consumption. Choose granularity separately: lean and Markdown accept `element`
+and `word`; requesting either without a granularity implies `element`.
 
 ```bash
 docray extract report.pdf --format lean
 docray extract report.pdf --format lean --granularity word
 curl -F file=@report.pdf 'http://localhost:41619/v1/extract?format=lean'
+docray extract report.pdf --format md
+curl -F file=@report.pdf 'http://localhost:41619/v1/extract?format=md'
 ```
 
 Lean was selected by measuring real tokenizer counts on a real-document
@@ -23,7 +26,47 @@ TOON was also measured and declined. Faithful TOON was worse than compact
 JSON for this data shape, while a type-grouped TOON variant still trailed lean
 by 7–10 percentage points.
 
-## Format specification
+## Markdown
+
+Markdown is an additive semantic projection over the existing extraction. It
+does not change the frozen schema 1.1 JSON response, compact JSON, or lean
+bytes. It ends with a newline and is deterministic for identical input bytes
+on a given platform and PDFium build.
+
+For PDF, docray geometrically clusters text into supported columns, guards
+against treating short inline font fragments as columns, orders each column
+top-to-bottom, and emits columns left-to-right. It joins nearby lines into
+paragraphs; recognizes bullet, numeric, and letter list markers; preserves
+bold, italic, and hyperlink runs; and separates pages with `---`. Heading
+levels H1-H4 are inferred from deterministic font-size ranks relative to the
+document's weighted median body size, with whole-line bold text promoted one
+tier. URI annotations are associated with the overlapping or nearest text.
+PDF table-region text remains plain reading-order text; Markdown does not
+invent table structure where extraction has none.
+
+DOCX Markdown renders authored flow structure directly: `h1`-`h9` and `title`
+roles become headings (levels above six use H6), quotes become block quotes,
+lists retain nesting, and logical tables become GFM pipe tables. PPTX uses its
+paged element model: placeholder roles inform headings, geometric sequencing
+sets reading order, and existing first-class PowerPoint tables become GFM pipe
+tables. Images without an exported asset URL are represented by an HTML
+comment. Page and section breaks render as `---`.
+
+Warnings remain visible as GFM warning callouts. Non-visible hidden-channel
+items are retained as trailing `docray-hidden` HTML comments, so they do not
+appear as document prose. Markdown escapes document-controlled Markdown/HTML
+syntax and percent-encodes unsafe link-target characters.
+
+Markdown is a reading format, not a lossless replacement for JSON. It omits
+geometry, source hashes, paint, and reconstruction metadata. Use `element` for
+Markdown unless the same request plumbing also needs `word`; Markdown itself
+does not emit coordinate detail. Use JSON `char` for the full archival model.
+
+Native CLI and HTTP use `--format md` / `?format=md`; HTTP returns
+`Content-Type: text/markdown; charset=utf-8`. The WASM API exports
+`extract_markdown(bytes, granularity, max_input_bytes, max_output_bytes)`.
+
+## Lean format specification
 
 Lean is deterministic, line-oriented UTF-8 with `\n` separators and a final
 newline. The first two lines are always:
@@ -200,8 +243,8 @@ Lean is a reading format, not a lossless replacement for JSON:
   is required for reconstruction.
 - It supports only `element` and `word`; use JSON for the lossless `char`
   hierarchy and reconstruction metadata.
-- The Rust/Wasm API emits JSON only. Lean is available from the native CLI and
-  HTTP server.
+- WASM exposes `extract`, `extract_lean`, and `extract_markdown`; all three
+  share the same input/output caps and stable error envelope.
 
 Lean HTTP successes use `Content-Type: text/plain; charset=utf-8`. Async jobs
 persist their requested format with the job, so the result endpoint returns

--- a/book/src/pptx.md
+++ b/book/src/pptx.md
@@ -5,11 +5,12 @@ page. Slide dimensions are read from the presentation in EMUs, converted at
 12,700 EMUs per point, and reported in the same top-left, y-down point space as
 PDF output.
 
-PPTX is available at `element` granularity and in lean output:
+PPTX is available at `element` granularity and in lean or Markdown output:
 
 ```bash
 docray extract deck.pptx --granularity element
 docray extract deck.pptx --format lean
+docray extract deck.pptx --format md
 ```
 
 An omitted granularity defaults to `element` for PPTX, so `docray extract
@@ -69,9 +70,10 @@ deck.pptx` (or a plain upload) just works. Requesting finer detail — `char` or
   shape, picture, and frame rotation/flip transforms are flattened into slide
   coordinates.
 
-Elements follow PowerPoint z-order: master shapes, layout shapes, then the
+JSON and lean elements follow PowerPoint z-order: master shapes, layout shapes, then the
 slide's own `p:spTree`, with document order preserved inside each layer. docray
-does not infer a semantic reading order. Hidden items are explicitly marked as
+does not infer a semantic reading order for those lossless/positional formats.
+Markdown applies geometric column and reading-order sequencing. Hidden items are explicitly marked as
 non-visible context in JSON and lean so consumers do not mistake notes or
 accessibility metadata for slide-visible text.
 

--- a/crates/docray-cli/src/main.rs
+++ b/crates/docray-cli/src/main.rs
@@ -65,7 +65,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Cmd {
-    /// Extract a document to JSON or lean text on stdout.
+    /// Extract a document to JSON, lean text, or Markdown on stdout.
     Extract {
         file: String,
         #[arg(long)]
@@ -75,8 +75,8 @@ enum Cmd {
         /// Output detail: element, word, or char. Omit for byte-identical v1.1 output.
         #[arg(long, value_parser = parse_granularity)]
         granularity: Option<Granularity>,
-        /// Output encoding: json or lean. Lean implies element granularity.
-        #[arg(long, default_value = "json", value_name = "json|lean")]
+        /// Output encoding: json, lean, or md. Text formats imply element granularity.
+        #[arg(long, default_value = "json", value_name = "json|lean|md")]
         format: String,
     },
 }
@@ -110,9 +110,11 @@ fn run_extract(
         Err(message) => return fail_bad_format(&message),
     };
     let granularity = match (format, granularity) {
-        (OutputFormat::Lean, None) => Some(Granularity::Element),
-        (OutputFormat::Lean, Some(Granularity::Char)) => {
-            return fail_bad_format("lean format requires element or word granularity")
+        (OutputFormat::Lean | OutputFormat::Markdown, None) => Some(Granularity::Element),
+        (OutputFormat::Lean | OutputFormat::Markdown, Some(Granularity::Char)) => {
+            return fail_bad_format(&format!(
+                "{format} format requires element or word granularity"
+            ))
         }
         (_, granularity) => granularity,
     };
@@ -148,6 +150,10 @@ fn run_extract(
     match result {
         Ok(extraction) => {
             let output = match format {
+                OutputFormat::Markdown => match extraction {
+                    DocumentExtraction::Paged(extraction) => extraction.to_markdown(),
+                    DocumentExtraction::Flow(extraction) => extraction.to_markdown(),
+                },
                 OutputFormat::Lean => match extraction {
                     DocumentExtraction::Paged(extraction) => match extraction
                         .with_granularity(granularity.expect("lean granularity is validated above"))

--- a/crates/docray-cli/tests/cli.rs
+++ b/crates/docray-cli/tests/cli.rs
@@ -70,6 +70,26 @@ fn lean_char_exits_7_with_bad_format_envelope() {
 }
 
 #[test]
+fn markdown_defaults_to_element_and_char_is_rejected() {
+    dps()
+        .arg("extract")
+        .arg(testdata("simple.pdf"))
+        .args(["--format", "md"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Hello World"))
+        .stdout(predicate::str::contains("# **Bold Title**"));
+
+    dps()
+        .arg("extract")
+        .arg(testdata("simple.pdf"))
+        .args(["--format", "md", "--granularity", "char"])
+        .assert()
+        .code(7)
+        .stderr(predicate::str::contains("\"code\":\"bad_format\""));
+}
+
+#[test]
 fn unknown_output_format_exits_7_with_bad_format_envelope() {
     dps()
         .arg("extract")
@@ -158,6 +178,14 @@ fn pptx_explicit_element_and_lean_work() {
         .assert()
         .success()
         .stdout(predicate::str::starts_with("#docray element v1.6 pages=1"));
+
+    dps()
+        .arg("extract")
+        .arg(testdata("pptx/table.pptx"))
+        .args(["--format", "md"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("| Merged |  |"));
 }
 
 #[test]
@@ -192,6 +220,15 @@ fn docx_defaults_to_element_rejects_finer_and_supports_lean() {
             "#docray element v1.7 sections=1",
         ))
         .stdout(predicate::str::contains("Cached heading"));
+
+    dps()
+        .arg("extract")
+        .arg(testdata("docx/roles.docx"))
+        .args(["--format", "md"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("# H1"))
+        .stdout(predicate::str::contains("## H2"));
 }
 
 #[test]

--- a/crates/docray-docx/tests/golden.rs
+++ b/crates/docray-docx/tests/golden.rs
@@ -63,6 +63,22 @@ fn element_and_lean_goldens_are_byte_exact_on_every_platform() {
 }
 
 #[test]
+fn markdown_goldens_are_byte_exact() {
+    let golden_dir = root().join("testdata/golden/docx");
+    for name in ["roles", "numbering", "tables", "hyperlinks"] {
+        let markdown = fixture(&format!("{name}.docx")).to_markdown();
+        let path = golden_dir.join(format!("{name}.md"));
+        if std::env::var_os("UPDATE_GOLDEN").is_some() {
+            fs::write(&path, &markdown).unwrap();
+        } else {
+            let expected = fs::read_to_string(&path)
+                .unwrap_or_else(|_| panic!("missing golden {path:?}; run with UPDATE_GOLDEN=1"));
+            assert_eq!(markdown, expected, "Markdown golden mismatch for {name}");
+        }
+    }
+}
+
+#[test]
 fn capabilities_are_element_only_flow() {
     let capabilities = DocxExtractor.capabilities();
     assert_eq!(capabilities.finest_granularity, Granularity::Element);

--- a/crates/docray-model/src/flow.rs
+++ b/crates/docray-model/src/flow.rs
@@ -61,7 +61,7 @@ pub enum Story {
 }
 
 impl Story {
-    fn blocks(&self) -> &[Block] {
+    pub(crate) fn blocks(&self) -> &[Block] {
         match self {
             Story::Default { blocks } | Story::First { blocks } | Story::Even { blocks } => blocks,
         }

--- a/crates/docray-model/src/lib.rs
+++ b/crates/docray-model/src/lib.rs
@@ -4,6 +4,7 @@ use std::fmt::Write as _;
 use std::str::FromStr;
 
 mod flow;
+mod markdown;
 
 pub use flow::*;
 
@@ -283,6 +284,7 @@ impl Serialize for Granularity {
 pub enum OutputFormat {
     Json,
     Lean,
+    Markdown,
 }
 
 impl OutputFormat {
@@ -290,6 +292,7 @@ impl OutputFormat {
         match self {
             OutputFormat::Json => "json",
             OutputFormat::Lean => "lean",
+            OutputFormat::Markdown => "md",
         }
     }
 }
@@ -307,7 +310,8 @@ impl FromStr for OutputFormat {
         match value {
             "json" => Ok(OutputFormat::Json),
             "lean" => Ok(OutputFormat::Lean),
-            _ => Err(format!("expected json or lean; got {value:?}")),
+            "md" => Ok(OutputFormat::Markdown),
+            _ => Err(format!("expected json, lean, or md; got {value:?}")),
         }
     }
 }

--- a/crates/docray-model/src/markdown.rs
+++ b/crates/docray-model/src/markdown.rs
@@ -1,0 +1,1256 @@
+use super::{
+    AnnotationElement, BBox, Block, BreakKind, Element, Extraction, FlowExtraction, FlowTableCell,
+    Font, HiddenItem, ListKind, Page, TableElement, TextRun,
+};
+use std::collections::BTreeMap;
+use std::fmt;
+use std::fmt::Write as _;
+
+#[derive(Clone)]
+struct Segment {
+    text: String,
+    bold: bool,
+    italic: bool,
+    href: Option<String>,
+}
+
+#[derive(Clone)]
+struct PageBlock {
+    id: String,
+    bbox: BBox,
+    content: String,
+    size: f64,
+    bold: bool,
+    segments: Vec<Segment>,
+    column: usize,
+    heading: Option<usize>,
+    rendered_override: Option<String>,
+}
+
+impl PageBlock {
+    fn width(&self) -> f64 {
+        (self.bbox.x1 - self.bbox.x0).max(0.0)
+    }
+
+    fn height(&self) -> f64 {
+        (self.bbox.y1 - self.bbox.y0).max(0.0)
+    }
+}
+
+impl Extraction {
+    /// Renders deterministic GFM Markdown from the lossless paged model.
+    pub fn to_markdown(&self) -> String {
+        let mut output = String::new();
+        self.write_markdown(&mut output)
+            .expect("writing to a String cannot fail");
+        output
+    }
+
+    /// Streams deterministic GFM Markdown into a bounded or ordinary writer.
+    pub fn write_markdown<W: fmt::Write>(&self, output: &mut W) -> fmt::Result {
+        let page_blocks = self
+            .pages
+            .iter()
+            .map(|page| (page.width, blocks_for_page(page, &self.source.format)))
+            .collect::<Vec<_>>();
+        let body_size =
+            weighted_median_font(page_blocks.iter().flat_map(|(_, blocks)| blocks.iter()));
+        let pages = page_blocks
+            .into_iter()
+            .map(|(page_width, blocks)| render_page(blocks, page_width, body_size))
+            .filter(|page| !page.is_empty())
+            .collect::<Vec<_>>();
+        for (index, page) in pages.iter().enumerate() {
+            if index > 0 {
+                output.write_str("\n\n---\n\n")?;
+            }
+            output.write_str(page)?;
+        }
+        let hidden = self
+            .pages
+            .iter()
+            .flat_map(|page| &page.hidden)
+            .collect::<Vec<_>>();
+        let has_context = !self.warnings.is_empty() || !hidden.is_empty();
+        if !pages.is_empty() && has_context {
+            output.write_str("\n\n")?;
+        }
+        write_trailing_context(output, &self.warnings, &hidden)?;
+        if !pages.is_empty() || has_context {
+            output.write_char('\n')?;
+        }
+        Ok(())
+    }
+}
+
+impl FlowExtraction {
+    /// Renders deterministic GFM Markdown from authored flow structure.
+    pub fn to_markdown(&self) -> String {
+        let mut output = String::new();
+        self.write_markdown(&mut output)
+            .expect("writing to a String cannot fail");
+        output
+    }
+
+    /// Streams deterministic GFM Markdown into a bounded or ordinary writer.
+    pub fn write_markdown<W: fmt::Write>(&self, output: &mut W) -> fmt::Result {
+        let wrote_document = {
+            let mut state = BlockWriter::new(output);
+            for section in &self.sections {
+                for story in &section.headers {
+                    state.write_flow_blocks(story.blocks())?;
+                }
+                state.write_flow_blocks(&section.blocks)?;
+                for story in &section.footers {
+                    state.write_flow_blocks(story.blocks())?;
+                }
+            }
+            state.wrote_block
+        };
+        let hidden = self
+            .sections
+            .iter()
+            .flat_map(|section| &section.hidden)
+            .collect::<Vec<_>>();
+        let has_context = !self.warnings.is_empty() || !hidden.is_empty();
+        if wrote_document && has_context {
+            output.write_str("\n\n")?;
+        }
+        write_trailing_context(output, &self.warnings, &hidden)?;
+        if wrote_document || has_context {
+            output.write_char('\n')?;
+        }
+        Ok(())
+    }
+}
+
+struct BlockWriter<'a, W> {
+    output: &'a mut W,
+    wrote_block: bool,
+}
+
+impl<'a, W: fmt::Write> BlockWriter<'a, W> {
+    fn new(output: &'a mut W) -> Self {
+        Self {
+            output,
+            wrote_block: false,
+        }
+    }
+
+    fn block(&mut self, text: &str) -> fmt::Result {
+        if text.is_empty() {
+            return Ok(());
+        }
+        if self.wrote_block {
+            self.output.write_str("\n\n")?;
+        }
+        self.output.write_str(text)?;
+        self.wrote_block = true;
+        Ok(())
+    }
+
+    fn write_flow_blocks(&mut self, blocks: &[Block]) -> fmt::Result {
+        for block in blocks {
+            match block {
+                Block::Paragraph {
+                    role,
+                    runs,
+                    content,
+                    list,
+                    breaks_before,
+                    ..
+                } => {
+                    for kind in breaks_before {
+                        self.write_break(*kind)?;
+                    }
+                    let rendered = render_runs(content, runs, None);
+                    let line = if let Some(list) = list {
+                        let indent = "  ".repeat(list.level as usize);
+                        let marker = match list.kind {
+                            ListKind::Ordered => "1.",
+                            ListKind::Bullet => "-",
+                        };
+                        format!("{indent}{marker} {rendered}")
+                    } else if let Some(level) = heading_role(role) {
+                        format!("{} {rendered}", "#".repeat(level.min(6)))
+                    } else if role == "title" {
+                        format!("# {rendered}")
+                    } else if role == "quote" {
+                        rendered
+                            .lines()
+                            .map(|line| format!("> {line}"))
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    } else {
+                        rendered
+                    };
+                    self.block(&line)?;
+                }
+                Block::Table {
+                    rows, cols, cells, ..
+                } => self.block(&render_flow_table(*rows, *cols, cells))?,
+                Block::Image { .. } => self.block("<!-- image -->")?,
+                Block::Textbox { blocks, .. } => self.write_flow_blocks(blocks)?,
+                Block::Break { kind } => self.write_break(*kind)?,
+            }
+        }
+        Ok(())
+    }
+
+    fn write_break(&mut self, kind: BreakKind) -> fmt::Result {
+        match kind {
+            BreakKind::Page | BreakKind::Section => self.block("---"),
+            BreakKind::Column => Ok(()),
+        }
+    }
+}
+
+fn render_page(mut blocks: Vec<PageBlock>, page_width: f64, body_size: f64) -> String {
+    if blocks.is_empty() {
+        return String::new();
+    }
+    assign_columns(&mut blocks, page_width);
+    blocks = merge_inline_blocks(blocks);
+    infer_headings(&mut blocks, body_size);
+    blocks.sort_by(|a, b| {
+        a.column
+            .cmp(&b.column)
+            .then_with(|| a.bbox.y0.total_cmp(&b.bbox.y0))
+            .then_with(|| a.bbox.x0.total_cmp(&b.bbox.x0))
+            .then_with(|| a.bbox.y1.total_cmp(&b.bbox.y1))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
+    let mut output: Vec<String> = Vec::new();
+    let mut previous: Option<&PageBlock> = None;
+    for block in &blocks {
+        let rendered = if let Some(table) = &block.rendered_override {
+            table.clone()
+        } else if let Some((kind, body_start)) = list_item(&block.content) {
+            let body_segments = segments_after_byte(&block.segments, body_start);
+            let marker = match kind {
+                ListMarker::Ordered(number) => format!("{number}."),
+                ListMarker::Bullet => "-".to_string(),
+                ListMarker::Letter(marker) => format!("- {marker}"),
+            };
+            format!("{marker} {}", render_segments(&body_segments))
+        } else {
+            let content = render_segments(&block.segments);
+            if let Some(level) = block.heading {
+                format!("{} {content}", "#".repeat(level.min(6)))
+            } else {
+                content
+            }
+        };
+        if rendered.is_empty() {
+            continue;
+        }
+        let break_before = previous.is_none()
+            || previous.is_some_and(|prev| needs_paragraph_break(prev, block, body_size));
+        if break_before {
+            output.push(rendered);
+        } else if let Some(last) = output.last_mut() {
+            last.push(' ');
+            last.push_str(&rendered);
+        }
+        previous = Some(block);
+    }
+    output.join("\n\n")
+}
+
+fn blocks_for_page(page: &Page, source_format: &str) -> Vec<PageBlock> {
+    let roles: BTreeMap<&str, usize> = page
+        .hidden
+        .iter()
+        .filter(|item| item.kind == "role")
+        .filter_map(|item| {
+            let id = item.element.as_deref()?;
+            let level = match item.content.as_str() {
+                "title" | "ctrTitle" => 1,
+                "subTitle" => 2,
+                role => heading_role(role)?,
+            };
+            Some((id, level))
+        })
+        .collect();
+    let mut blocks = Vec::new();
+    let mut annotations = Vec::new();
+    for element in &page.elements {
+        match element {
+            Element::Text(text) if !clean_text(&text.content).is_empty() => {
+                blocks.push(PageBlock {
+                    id: text.id.clone(),
+                    bbox: text.bbox,
+                    content: text.content.clone(),
+                    size: finite_or(text.font.size, 0.0),
+                    bold: whole_line_bold(&text.font, text.runs.as_deref()),
+                    segments: segments_from_text(&text.content, &text.font, text.runs.as_deref()),
+                    column: 0,
+                    heading: roles.get(text.id.as_str()).copied(),
+                    rendered_override: None,
+                });
+            }
+            Element::Table(table) if source_format == "pptx" => blocks.push(PageBlock {
+                id: table.id.clone(),
+                bbox: table.bbox,
+                content: table
+                    .cells
+                    .iter()
+                    .map(|cell| cell.content.as_str())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+                size: 0.0,
+                bold: false,
+                segments: Vec::new(),
+                column: 0,
+                heading: None,
+                rendered_override: Some(render_paged_table(table)),
+            }),
+            Element::Table(table) => {
+                // PDF table structure is intentionally deferred to #63. Until then,
+                // emit only cell text in geometric reading order.
+                for (index, cell) in table.cells.iter().enumerate() {
+                    if clean_text(&cell.content).is_empty() {
+                        continue;
+                    }
+                    let font = cell
+                        .runs
+                        .as_deref()
+                        .and_then(|runs| runs.first())
+                        .map(|run| &run.font)
+                        .cloned()
+                        .unwrap_or_else(default_font);
+                    blocks.push(PageBlock {
+                        id: format!("{}-c{index}", table.id),
+                        bbox: cell.bbox,
+                        content: cell.content.clone(),
+                        size: finite_or(font.size, 0.0),
+                        bold: whole_line_bold(&font, cell.runs.as_deref()),
+                        segments: segments_from_text(&cell.content, &font, cell.runs.as_deref()),
+                        column: 0,
+                        heading: None,
+                        rendered_override: None,
+                    });
+                }
+            }
+            Element::Annotation(annotation) if annotation.uri.is_some() => {
+                annotations.push(annotation)
+            }
+            _ => {}
+        }
+    }
+    associate_annotations(&mut blocks, &annotations);
+    blocks
+}
+
+fn default_font() -> Font {
+    Font {
+        name: String::new(),
+        size: 0.0,
+        bold: false,
+        italic: false,
+    }
+}
+
+fn whole_line_bold(font: &Font, runs: Option<&[TextRun]>) -> bool {
+    let Some(runs) = runs.filter(|runs| !runs.is_empty()) else {
+        return font.bold;
+    };
+    let visible = runs
+        .iter()
+        .filter(|run| !clean_text(&run.content).is_empty())
+        .collect::<Vec<_>>();
+    if visible.is_empty() {
+        font.bold
+    } else {
+        visible.iter().all(|run| run.font.bold)
+    }
+}
+
+fn segments_from_text(content: &str, font: &Font, runs: Option<&[TextRun]>) -> Vec<Segment> {
+    let Some(runs) = runs.filter(|runs| !runs.is_empty()) else {
+        return vec![segment(content, font, None)];
+    };
+    let mut result = Vec::new();
+    let mut cursor = 0;
+    for run in runs {
+        if let Some(relative) = content[cursor..].find(&run.content) {
+            let start = cursor + relative;
+            if start > cursor {
+                result.push(segment(&content[cursor..start], font, None));
+            }
+            result.push(segment(&run.content, &run.font, run.href.clone()));
+            cursor = start + run.content.len();
+        } else {
+            result.push(segment(&run.content, &run.font, run.href.clone()));
+        }
+    }
+    if cursor < content.len() {
+        result.push(segment(&content[cursor..], font, None));
+    }
+    result
+}
+
+fn segment(text: &str, font: &Font, href: Option<String>) -> Segment {
+    Segment {
+        text: text.to_string(),
+        bold: font.bold,
+        italic: font.italic,
+        href,
+    }
+}
+
+fn associate_annotations(blocks: &mut [PageBlock], annotations: &[&AnnotationElement]) {
+    for annotation in annotations {
+        let Some(uri) = &annotation.uri else { continue };
+        let Some((index, _)) = blocks.iter().enumerate().min_by(|(_, a), (_, b)| {
+            overlap_area(b, &annotation.bbox)
+                .total_cmp(&overlap_area(a, &annotation.bbox))
+                .then_with(|| {
+                    distance_to_box(a, &annotation.bbox)
+                        .total_cmp(&distance_to_box(b, &annotation.bbox))
+                })
+                .then_with(|| a.bbox.y0.total_cmp(&b.bbox.y0))
+                .then_with(|| a.bbox.x0.total_cmp(&b.bbox.x0))
+                .then_with(|| a.id.cmp(&b.id))
+        }) else {
+            continue;
+        };
+        for segment in &mut blocks[index].segments {
+            if segment.href.is_none() && !clean_text(&segment.text).is_empty() {
+                segment.href = Some(uri.clone());
+            }
+        }
+    }
+}
+
+fn overlap_area(block: &PageBlock, bbox: &BBox) -> f64 {
+    (block.bbox.x1.min(bbox.x1) - block.bbox.x0.max(bbox.x0)).max(0.0)
+        * (block.bbox.y1.min(bbox.y1) - block.bbox.y0.max(bbox.y0)).max(0.0)
+}
+
+fn distance_to_box(block: &PageBlock, bbox: &BBox) -> f64 {
+    let dx = (block.bbox.x0 + block.bbox.x1 - bbox.x0 - bbox.x1) / 2.0;
+    let dy = (block.bbox.y0 + block.bbox.y1 - bbox.y0 - bbox.y1) / 2.0;
+    dx.hypot(dy)
+}
+
+fn weighted_median_font<'a>(blocks: impl IntoIterator<Item = &'a PageBlock>) -> f64 {
+    let mut weighted = Vec::new();
+    let mut fallback = Vec::new();
+    for block in blocks
+        .into_iter()
+        .filter(|block| block.rendered_override.is_none() && block.size > 0.0)
+    {
+        fallback.push(block.size);
+        let weight = (clean_text(&block.content).chars().count() / 8).clamp(1, 12);
+        weighted.extend(std::iter::repeat_n(block.size, weight));
+    }
+    median(if weighted.is_empty() {
+        &mut fallback
+    } else {
+        &mut weighted
+    })
+    .unwrap_or(10.0)
+}
+
+fn median(values: &mut [f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(f64::total_cmp);
+    let middle = values.len() / 2;
+    Some(if values.len().is_multiple_of(2) {
+        (values[middle - 1] + values[middle]) / 2.0
+    } else {
+        values[middle]
+    })
+}
+
+fn infer_headings(blocks: &mut [PageBlock], body_size: f64) {
+    let threshold = (body_size + 1.0).max(body_size * 1.12);
+    let candidate_sizes = blocks
+        .iter()
+        .filter(|block| {
+            block.rendered_override.is_none()
+                && block.heading.is_none()
+                && (block.size >= threshold || (block.bold && block.size >= body_size * 0.98))
+        })
+        .map(|block| block.size)
+        .collect::<Vec<_>>();
+    let ranks = cluster_sizes(candidate_sizes, body_size);
+    for block in blocks.iter_mut().filter(|block| block.heading.is_none()) {
+        if block.rendered_override.is_some()
+            || !(block.size >= threshold || (block.bold && block.size >= body_size * 0.98))
+        {
+            continue;
+        }
+        let Some((rank, _)) = ranks
+            .iter()
+            .enumerate()
+            .min_by(|(_, a), (_, b)| (*a - block.size).abs().total_cmp(&(*b - block.size).abs()))
+        else {
+            continue;
+        };
+        let mut level = (rank + 1).min(4);
+        if block.bold && level > 1 {
+            level -= 1;
+        }
+        block.heading = Some(level);
+    }
+}
+
+fn cluster_sizes(mut sizes: Vec<f64>, body_size: f64) -> Vec<f64> {
+    sizes.sort_by(|a, b| b.total_cmp(a));
+    sizes.dedup_by(|a, b| a.total_cmp(b).is_eq());
+    let tolerance = 0.4_f64.max(body_size * 0.04);
+    let mut clusters: Vec<Vec<f64>> = Vec::new();
+    for size in sizes {
+        let joins = clusters.last_mut().is_some_and(|cluster| {
+            let mut copy = cluster.clone();
+            (size - median(&mut copy).unwrap_or(size)).abs() <= tolerance
+        });
+        if joins {
+            clusters.last_mut().unwrap().push(size);
+        } else {
+            clusters.push(vec![size]);
+        }
+    }
+    clusters
+        .into_iter()
+        .filter_map(|mut cluster| median(&mut cluster))
+        .collect()
+}
+
+fn assign_columns(blocks: &mut [PageBlock], page_width: f64) {
+    if blocks.is_empty() {
+        return;
+    }
+    let threshold = (page_width * 0.055).clamp(18.0, 42.0);
+    let mut anchors = blocks
+        .iter()
+        .enumerate()
+        .filter(|(_, block)| {
+            clean_text(&block.content).chars().count() >= 20 || block.width() >= page_width * 0.16
+        })
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    if anchors.is_empty() {
+        anchors.extend(0..blocks.len());
+    }
+    anchors.sort_by(|a, b| {
+        blocks[*a]
+            .bbox
+            .x0
+            .total_cmp(&blocks[*b].bbox.x0)
+            .then_with(|| blocks[*a].bbox.y0.total_cmp(&blocks[*b].bbox.y0))
+            .then_with(|| blocks[*a].id.cmp(&blocks[*b].id))
+    });
+    let mut raw: Vec<Vec<usize>> = Vec::new();
+    for index in anchors.iter().copied() {
+        let new_cluster = raw.last().is_none_or(|cluster| {
+            blocks[index].bbox.x0 - blocks[*cluster.last().unwrap()].bbox.x0 > threshold
+        });
+        if new_cluster {
+            raw.push(vec![index]);
+        } else {
+            raw.last_mut().unwrap().push(index);
+        }
+    }
+    let minimum_support = 4_usize.max((anchors.len() * 8).div_ceil(100));
+    let mut major = raw
+        .iter()
+        .filter(|cluster| cluster.len() >= minimum_support)
+        .cloned()
+        .collect::<Vec<_>>();
+    if major.is_empty() {
+        major.push(
+            raw.into_iter()
+                .max_by(|a, b| {
+                    a.len()
+                        .cmp(&b.len())
+                        .then_with(|| blocks[b[0]].bbox.x0.total_cmp(&blocks[a[0]].bbox.x0))
+                })
+                .unwrap(),
+        );
+    }
+    let centers = major
+        .iter()
+        .map(|cluster| {
+            let mut starts = cluster
+                .iter()
+                .map(|index| blocks[*index].bbox.x0)
+                .collect::<Vec<_>>();
+            median(&mut starts).unwrap()
+        })
+        .collect::<Vec<_>>();
+    let anchor_columns = major
+        .iter()
+        .enumerate()
+        .flat_map(|(column, cluster)| cluster.iter().map(move |index| (*index, column)))
+        .collect::<BTreeMap<_, _>>();
+    for index in 0..blocks.len() {
+        if let Some(column) = anchor_columns.get(&index) {
+            blocks[index].column = *column;
+            continue;
+        }
+        let same_line = anchors.iter().copied().filter(|anchor| {
+            vertical_overlap(&blocks[index], &blocks[*anchor])
+                > blocks[index].height().min(blocks[*anchor].height()) * 0.35
+        });
+        let nearest_anchor = same_line.min_by(|a, b| {
+            horizontal_distance(&blocks[index], &blocks[*a])
+                .total_cmp(&horizontal_distance(&blocks[index], &blocks[*b]))
+                .then_with(|| {
+                    (blocks[index].bbox.x0 - blocks[*a].bbox.x0)
+                        .abs()
+                        .total_cmp(&(blocks[index].bbox.x0 - blocks[*b].bbox.x0).abs())
+                })
+                .then_with(|| blocks[*a].id.cmp(&blocks[*b].id))
+        });
+        let x = nearest_anchor.map_or(blocks[index].bbox.x0, |anchor| blocks[anchor].bbox.x0);
+        blocks[index].column = centers
+            .iter()
+            .enumerate()
+            .min_by(|(ai, a), (bi, b)| (x - **a).abs().total_cmp(&(x - **b).abs()).then(ai.cmp(bi)))
+            .map(|(column, _)| column)
+            .unwrap_or(0);
+    }
+    let mut order = (0..centers.len()).collect::<Vec<_>>();
+    order.sort_by(|a, b| centers[*a].total_cmp(&centers[*b]).then(a.cmp(b)));
+    let remap = order
+        .iter()
+        .enumerate()
+        .map(|(new, old)| (*old, new))
+        .collect::<BTreeMap<_, _>>();
+    for block in blocks {
+        block.column = remap[&block.column];
+    }
+}
+
+fn vertical_overlap(a: &PageBlock, b: &PageBlock) -> f64 {
+    (a.bbox.y1.min(b.bbox.y1) - a.bbox.y0.max(b.bbox.y0)).max(0.0)
+}
+
+fn horizontal_distance(a: &PageBlock, b: &PageBlock) -> f64 {
+    let center = (a.bbox.x0 + a.bbox.x1) / 2.0;
+    if b.bbox.x0 <= center && center <= b.bbox.x1 {
+        0.0
+    } else {
+        (a.bbox.x0 - b.bbox.x1)
+            .abs()
+            .min((a.bbox.x1 - b.bbox.x0).abs())
+    }
+}
+
+fn merge_inline_blocks(mut blocks: Vec<PageBlock>) -> Vec<PageBlock> {
+    blocks.sort_by(|a, b| {
+        a.column
+            .cmp(&b.column)
+            .then_with(|| a.bbox.y0.total_cmp(&b.bbox.y0))
+            .then_with(|| a.bbox.x0.total_cmp(&b.bbox.x0))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    let mut rows: Vec<Vec<PageBlock>> = Vec::new();
+    for block in blocks {
+        if block.rendered_override.is_some() {
+            rows.push(vec![block]);
+            continue;
+        }
+        let candidate = rows
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| row[0].rendered_override.is_none() && row[0].column == block.column)
+            .filter(|(_, row)| {
+                row.iter()
+                    .map(|item| vertical_overlap(item, &block))
+                    .fold(0.0, f64::max)
+                    > row
+                        .iter()
+                        .map(PageBlock::height)
+                        .fold(0.0, f64::max)
+                        .min(block.height())
+                        * 0.35
+            })
+            .min_by(|(_, a), (_, b)| {
+                let mut ay = a.iter().map(|item| item.bbox.y0).collect::<Vec<_>>();
+                let mut by = b.iter().map(|item| item.bbox.y0).collect::<Vec<_>>();
+                (median(&mut ay).unwrap() - block.bbox.y0)
+                    .abs()
+                    .total_cmp(&(median(&mut by).unwrap() - block.bbox.y0).abs())
+            })
+            .map(|(index, _)| index);
+        if let Some(index) = candidate {
+            rows[index].push(block);
+        } else {
+            rows.push(vec![block]);
+        }
+    }
+    rows.into_iter().map(merge_row).collect()
+}
+
+fn merge_row(mut row: Vec<PageBlock>) -> PageBlock {
+    if row.len() == 1 {
+        return row.pop().unwrap();
+    }
+    row.sort_by(|a, b| {
+        a.bbox
+            .x0
+            .total_cmp(&b.bbox.x0)
+            .then_with(|| a.bbox.x1.total_cmp(&b.bbox.x1))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    let mut merged = row[0].clone();
+    merged.id = row
+        .iter()
+        .map(|item| item.id.as_str())
+        .min()
+        .unwrap()
+        .to_string();
+    merged.bbox = BBox {
+        x0: row
+            .iter()
+            .map(|item| item.bbox.x0)
+            .fold(f64::INFINITY, f64::min),
+        y0: row
+            .iter()
+            .map(|item| item.bbox.y0)
+            .fold(f64::INFINITY, f64::min),
+        x1: row
+            .iter()
+            .map(|item| item.bbox.x1)
+            .fold(f64::NEG_INFINITY, f64::max),
+        y1: row
+            .iter()
+            .map(|item| item.bbox.y1)
+            .fold(f64::NEG_INFINITY, f64::max),
+    };
+    merged.content.clear();
+    merged.segments.clear();
+    merged.size = row.iter().map(|item| item.size).fold(0.0, f64::max);
+    merged.bold = row.iter().all(|item| item.bold);
+    merged.heading = row.iter().filter_map(|item| item.heading).min();
+    for (index, item) in row.iter().enumerate() {
+        if index > 0 {
+            let previous = &row[index - 1];
+            if item.bbox.x0 - previous.bbox.x1 > 1.0_f64.max(item.size * 0.12) {
+                merged.content.push(' ');
+                merged.segments.push(Segment {
+                    text: " ".into(),
+                    bold: false,
+                    italic: false,
+                    href: None,
+                });
+            }
+        }
+        merged.content.push_str(&item.content);
+        merged.segments.extend(item.segments.clone());
+    }
+    merged
+}
+
+#[derive(Clone)]
+enum ListMarker {
+    Ordered(usize),
+    Bullet,
+    Letter(String),
+}
+
+fn list_item(text: &str) -> Option<(ListMarker, usize)> {
+    let leading = text.len() - text.trim_start().len();
+    let trimmed = &text[leading..];
+    let marker_end = trimmed.find(char::is_whitespace)?;
+    let marker = &trimmed[..marker_end];
+    let rest = &trimmed[marker_end..];
+    let whitespace = rest.len() - rest.trim_start().len();
+    if whitespace == 0 || rest.trim().is_empty() {
+        return None;
+    }
+    let kind = if matches!(
+        marker,
+        "•" | "‣" | "◦" | "⁃" | "∙" | "▪" | "●" | "·" | "*" | "+" | "-"
+    ) {
+        ListMarker::Bullet
+    } else {
+        let core = marker.strip_prefix('(').unwrap_or(marker);
+        let core = core.strip_suffix(['.', ')'])?;
+        if core.len() == 1 && core.as_bytes()[0].is_ascii_alphabetic() {
+            ListMarker::Letter(marker.to_string())
+        } else if (1..=3).contains(&core.len()) && core.bytes().all(|byte| byte.is_ascii_digit()) {
+            ListMarker::Ordered(core.parse().ok()?)
+        } else {
+            return None;
+        }
+    };
+    Some((kind, leading + marker_end + whitespace))
+}
+
+fn segments_after_byte(segments: &[Segment], mut skip: usize) -> Vec<Segment> {
+    let mut result = Vec::new();
+    for segment in segments {
+        if skip >= segment.text.len() {
+            skip -= segment.text.len();
+            continue;
+        }
+        let mut kept = segment.clone();
+        kept.text = kept.text[skip..].to_string();
+        skip = 0;
+        result.push(kept);
+    }
+    result
+}
+
+fn needs_paragraph_break(previous: &PageBlock, current: &PageBlock, body_size: f64) -> bool {
+    if previous.rendered_override.is_some()
+        || current.rendered_override.is_some()
+        || previous.heading.is_some()
+        || current.heading.is_some()
+        || list_item(&previous.content).is_some()
+        || list_item(&current.content).is_some()
+    {
+        return true;
+    }
+    let vertical_gap = current.bbox.y0 - previous.bbox.y1;
+    vertical_gap > 4.0_f64.max(body_size * 0.65)
+        || (current.bbox.x0 - previous.bbox.x0).abs() > 18.0_f64.max(body_size * 1.8)
+}
+
+fn render_runs(content: &str, runs: &[TextRun], fallback_href: Option<&str>) -> String {
+    let font = runs
+        .first()
+        .map(|run| &run.font)
+        .cloned()
+        .unwrap_or_else(default_font);
+    let mut segments = segments_from_text(content, &font, Some(runs));
+    if let Some(href) = fallback_href {
+        for segment in &mut segments {
+            if segment.href.is_none() {
+                segment.href = Some(href.to_string());
+            }
+        }
+    }
+    render_segments(&segments)
+}
+
+fn render_segments(segments: &[Segment]) -> String {
+    let mut output = String::new();
+    let mut pending = Separator::None;
+    for segment in segments {
+        let (leading, body, trailing) = split_whitespace(&segment.text);
+        pending = pending.max(separator(leading));
+        if !body.is_empty() {
+            push_separator(&mut output, pending);
+            pending = Separator::None;
+            let mut text = escape_markdown(&normalize_inner_whitespace(body));
+            if segment.bold && segment.italic {
+                text = format!("***{text}***");
+            } else if segment.bold {
+                text = format!("**{text}**");
+            } else if segment.italic {
+                text = format!("*{text}*");
+            }
+            if let Some(href) = &segment.href {
+                text = format!("[{text}]({})", escape_link_target(href));
+            }
+            output.push_str(&text);
+        }
+        pending = pending.max(separator(trailing));
+    }
+    output
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Separator {
+    None,
+    Space,
+    Line,
+}
+
+fn split_whitespace(text: &str) -> (&str, &str, &str) {
+    let start = text
+        .find(|ch: char| !ch.is_whitespace())
+        .unwrap_or(text.len());
+    let end = text
+        .rfind(|ch: char| !ch.is_whitespace())
+        .map_or(start, |index| {
+            index + text[index..].chars().next().unwrap().len_utf8()
+        });
+    (&text[..start], &text[start..end], &text[end..])
+}
+
+fn separator(text: &str) -> Separator {
+    if text
+        .chars()
+        .any(|ch| matches!(ch, '\n' | '\r' | '\u{2028}' | '\u{2029}'))
+    {
+        Separator::Line
+    } else if text.chars().any(char::is_whitespace) {
+        Separator::Space
+    } else {
+        Separator::None
+    }
+}
+
+fn push_separator(output: &mut String, separator: Separator) {
+    if output.is_empty() {
+        return;
+    }
+    match separator {
+        Separator::None => {}
+        Separator::Space => output.push(' '),
+        Separator::Line => output.push_str("<br>\n"),
+    }
+}
+
+fn normalize_inner_whitespace(text: &str) -> String {
+    let mut output = String::new();
+    let mut pending = Separator::None;
+    for ch in text.chars() {
+        if ch.is_whitespace() {
+            pending = pending.max(if matches!(ch, '\n' | '\r' | '\u{2028}' | '\u{2029}') {
+                Separator::Line
+            } else {
+                Separator::Space
+            });
+        } else {
+            push_separator(&mut output, pending);
+            pending = Separator::None;
+            output.push(ch);
+        }
+    }
+    output
+}
+
+fn escape_markdown(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    for ch in text.chars() {
+        match ch {
+            '&' => output.push_str("&amp;"),
+            '<' => output.push_str("&lt;"),
+            '>' => output.push_str("&gt;"),
+            '\\' | '*' | '_' | '[' | ']' | '`' | '|' | '#' | '!' => {
+                output.push('\\');
+                output.push(ch);
+            }
+            _ if ch.is_control() => output.push(' '),
+            _ => output.push(ch),
+        }
+    }
+    output
+}
+
+fn escape_link_target(uri: &str) -> String {
+    let mut output = String::new();
+    for ch in uri.chars() {
+        if ch.is_ascii_control() || matches!(ch, ' ' | '\\' | '(' | ')' | '<' | '>') {
+            for byte in ch.to_string().bytes() {
+                write!(output, "%{byte:02X}").expect("writing to a String cannot fail");
+            }
+        } else {
+            output.push(ch);
+        }
+    }
+    output
+}
+
+fn clean_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() {
+        value
+    } else {
+        fallback
+    }
+}
+
+fn heading_role(role: &str) -> Option<usize> {
+    let level = role.strip_prefix('h')?.parse::<usize>().ok()?;
+    (1..=9).contains(&level).then_some(level)
+}
+
+fn render_paged_table(table: &TableElement) -> String {
+    let cells = table
+        .cells
+        .iter()
+        .map(|cell| FlowTableCell {
+            row: cell.row,
+            col: cell.col,
+            row_span: cell.row_span,
+            col_span: cell.col_span,
+            content: cell.content.clone(),
+            runs: cell.runs.clone().unwrap_or_default(),
+            blocks: None,
+        })
+        .collect::<Vec<_>>();
+    render_flow_table(table.rows, table.cols, &cells)
+}
+
+fn render_flow_table(rows: usize, cols: usize, cells: &[FlowTableCell]) -> String {
+    if rows == 0 || cols == 0 {
+        return String::new();
+    }
+    let mut grid = vec![vec![String::new(); cols]; rows];
+    for cell in cells {
+        if cell.row < rows && cell.col < cols {
+            grid[cell.row][cell.col] =
+                render_runs(&cell.content, &cell.runs, None).replace("<br>\n", "<br>");
+        }
+    }
+    let row = |values: &[String]| format!("| {} |", values.join(" | "));
+    let mut output = row(&grid[0]);
+    output.push('\n');
+    output.push_str(&row(&vec!["---".to_string(); cols]));
+    for values in grid.iter().skip(1) {
+        output.push('\n');
+        output.push_str(&row(values));
+    }
+    output
+}
+
+fn write_trailing_context<W: fmt::Write>(
+    output: &mut W,
+    warnings: &[String],
+    hidden: &[&HiddenItem],
+) -> fmt::Result {
+    let mut wrote = false;
+    for warning in warnings {
+        if wrote {
+            output.write_str("\n\n")?;
+        }
+        write!(
+            output,
+            "> [!WARNING]\n> {}",
+            escape_markdown(&clean_text(warning))
+        )?;
+        wrote = true;
+    }
+    if wrote && !hidden.is_empty() {
+        output.write_str("\n\n")?;
+    }
+    for (index, item) in hidden.iter().enumerate() {
+        if index > 0 {
+            output.write_char('\n')?;
+        }
+        let element = item
+            .element
+            .as_deref()
+            .map(|id| format!(" [{id}]"))
+            .unwrap_or_default();
+        write!(
+            output,
+            "<!-- docray-hidden: {}{} {} -->",
+            safe_comment(&item.kind),
+            safe_comment(&element),
+            safe_comment(&clean_text(&item.content))
+        )?;
+    }
+    Ok(())
+}
+
+fn safe_comment(text: &str) -> String {
+    text.replace("--", "- -").replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DocMetadata, DocumentInfo, Page, Source, TextColor, TextElement};
+
+    fn text(id: &str, x: f64, y: f64, size: f64, bold: bool, content: &str) -> Element {
+        Element::Text(TextElement {
+            id: id.into(),
+            bbox: BBox {
+                x0: x,
+                y0: y,
+                x1: x + 180.0,
+                y1: y + 10.0,
+            },
+            content: content.into(),
+            font: Font {
+                name: "Test Sans".into(),
+                size,
+                bold,
+                italic: false,
+            },
+            color: TextColor {
+                fill: Some([0, 0, 0]),
+                stroke: None,
+            },
+            lines: None,
+            runs: None,
+        })
+    }
+
+    fn extraction(elements: Vec<Element>) -> Extraction {
+        Extraction {
+            schema_version: "1.1".into(),
+            source: Source {
+                format: "pdf".into(),
+                sha256: "unused".into(),
+                size_bytes: 0,
+            },
+            document: DocumentInfo {
+                page_count: 1,
+                metadata: DocMetadata {
+                    title: None,
+                    author: None,
+                },
+            },
+            warnings: vec![],
+            pages: vec![Page {
+                page_number: 1,
+                width: 612.0,
+                height: 792.0,
+                rotation: 0,
+                scanned: false,
+                elements,
+                hidden: vec![],
+            }],
+        }
+    }
+
+    #[test]
+    fn page_columns_are_left_to_right_not_content_stream_order() {
+        let mut elements = Vec::new();
+        for row in 0..4 {
+            elements.push(text(
+                &format!("right-{row}"),
+                350.0,
+                20.0 + row as f64 * 30.0,
+                12.0,
+                false,
+                &format!("Right column line {row}"),
+            ));
+            elements.push(text(
+                &format!("left-{row}"),
+                50.0,
+                20.0 + row as f64 * 30.0,
+                12.0,
+                false,
+                &format!("Left column line {row}"),
+            ));
+        }
+        let markdown = extraction(elements).to_markdown();
+        let positions = [
+            "Left column line 0",
+            "Left column line 3",
+            "Right column line 0",
+            "Right column line 3",
+        ]
+        .map(|needle| markdown.find(needle).unwrap());
+        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+
+    #[test]
+    fn heading_inference_lists_links_and_styles_are_exact() {
+        let mut linked = match text("link", 50.0, 90.0, 12.0, false, "• linked item") {
+            Element::Text(text) => text,
+            _ => unreachable!(),
+        };
+        linked.runs = Some(vec![TextRun {
+            content: "• linked item".into(),
+            font: Font {
+                name: "Test Sans".into(),
+                size: 12.0,
+                bold: false,
+                italic: true,
+            },
+            color: TextColor {
+                fill: Some([0, 0, 0]),
+                stroke: None,
+            },
+            href: None,
+        }]);
+        let annotation = Element::Annotation(AnnotationElement {
+            id: "annotation".into(),
+            bbox: linked.bbox,
+            subtype: "link".into(),
+            uri: Some("https://example.test/a b)".into()),
+        });
+        let markdown = extraction(vec![
+            text("title", 50.0, 10.0, 24.0, false, "Large title"),
+            text("body-a", 50.0, 45.0, 12.0, false, "Body line one"),
+            text("body-b", 50.0, 57.0, 12.0, false, "body line two"),
+            Element::Text(linked),
+            annotation,
+        ])
+        .to_markdown();
+        assert_eq!(
+            markdown,
+            "# Large title\n\nBody line one body line two\n\n- [*linked item*](https://example.test/a%20b%29)\n"
+        );
+    }
+
+    #[test]
+    fn hostile_hidden_content_cannot_close_the_markdown_comment() {
+        let mut document = extraction(vec![text("body", 50.0, 10.0, 12.0, false, "safe")]);
+        document.pages[0].hidden.push(HiddenItem {
+            kind: "comment".into(),
+            element: Some("body".into()),
+            content: "--><script>alert(1)</script>".into(),
+        });
+        let markdown = document.to_markdown();
+        assert!(!markdown.contains("--><script>"));
+        assert!(markdown.contains("- -&gt;<script&gt;alert(1)</script&gt;"));
+    }
+
+    #[test]
+    fn heading_baseline_is_document_wide_and_letter_markers_are_preserved() {
+        let mut document = extraction(vec![text(
+            "title",
+            50.0,
+            10.0,
+            15.0,
+            false,
+            "Document title",
+        )]);
+        document.document.page_count = 2;
+        document.pages.push(Page {
+            page_number: 2,
+            width: 612.0,
+            height: 792.0,
+            rotation: 0,
+            scanned: false,
+            elements: (0..4)
+                .map(|row| {
+                    text(
+                        &format!("body-{row}"),
+                        50.0,
+                        20.0 + row as f64 * 12.0,
+                        12.0,
+                        false,
+                        "A sufficiently long body line for weighting",
+                    )
+                })
+                .collect(),
+            hidden: vec![],
+        });
+        let markdown = document.to_markdown();
+        assert!(markdown.starts_with("# Document title\n\n---\n\n"));
+
+        let (marker, body_start) = list_item("a) alphabetic item").unwrap();
+        assert!(matches!(marker, ListMarker::Letter(value) if value == "a)"));
+        assert_eq!(&"a) alphabetic item"[body_start..], "alphabetic item");
+    }
+
+    #[test]
+    fn powerpoint_title_roles_override_font_inference() {
+        let mut document = extraction(vec![text(
+            "slide-title",
+            50.0,
+            10.0,
+            12.0,
+            false,
+            "Centered title",
+        )]);
+        document.source.format = "pptx".into();
+        document.pages[0].hidden.push(HiddenItem {
+            kind: "role".into(),
+            element: Some("slide-title".into()),
+            content: "ctrTitle".into(),
+        });
+        assert!(document.to_markdown().starts_with("# Centered title\n"));
+    }
+}

--- a/crates/docray-model/tests/flow.rs
+++ b/crates/docray-model/tests/flow.rs
@@ -224,6 +224,23 @@ fn lean_flow_renders_the_exact_flow_grammar() {
 }
 
 #[test]
+fn markdown_flow_renders_authored_structure_exactly() {
+    let actual = flow_extraction().to_markdown();
+    let expected = concat!(
+        "---\n\n",
+        "## **Heading** [text](https://example.test/h)\n\n",
+        "    1. Item text\n\n",
+        "| Cell text |  |\n",
+        "| --- | --- |\n\n",
+        "<!-- image -->\n\n",
+        "> Box text\n\n",
+        "---\n\n",
+        "<!-- docray-hidden: comment [s0-b1] Review this -->\n",
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
 fn hostile_flow_text_cannot_inject_lean_records() {
     let mut flow = flow_extraction();
     let blocks = &mut flow.sections[0].blocks;

--- a/crates/docray-model/tests/lean.rs
+++ b/crates/docray-model/tests/lean.rs
@@ -1,4 +1,16 @@
 use docray_model::*;
+use std::str::FromStr;
+
+#[test]
+fn output_format_accepts_markdown_without_changing_existing_names() {
+    assert_eq!(OutputFormat::from_str("json").unwrap(), OutputFormat::Json);
+    assert_eq!(OutputFormat::from_str("lean").unwrap(), OutputFormat::Lean);
+    assert_eq!(
+        OutputFormat::from_str("md").unwrap(),
+        OutputFormat::Markdown
+    );
+    assert_eq!(OutputFormat::Markdown.as_str(), "md");
+}
 
 fn extraction() -> Extraction {
     Extraction {

--- a/crates/docray-pdf/tests/golden.rs
+++ b/crates/docray-pdf/tests/golden.rs
@@ -190,6 +190,28 @@ fn lean_simple_goldens_match_on_linux() {
 }
 
 #[test]
+fn markdown_goldens_match_on_linux() {
+    if !cfg!(target_os = "linux") {
+        eprintln!("note: PDF Markdown goldens are canonical on Linux");
+        return;
+    }
+    ensure_pdfium_dir();
+    let update = std::env::var("UPDATE_GOLDEN").is_ok();
+    for name in ["simple", "link"] {
+        let bytes = fs::read(testdata().join(format!("{name}.pdf"))).unwrap();
+        let markdown = PdfExtractor.extract(&bytes, None).unwrap().to_markdown();
+        let golden_path = testdata().join("golden").join(format!("{name}.md"));
+        if update {
+            fs::write(&golden_path, markdown).unwrap();
+        } else {
+            let expected = fs::read_to_string(&golden_path)
+                .unwrap_or_else(|_| panic!("missing golden {golden_path:?}; regenerate on Linux"));
+            assert_eq!(markdown, expected, "Markdown golden mismatch for {name}");
+        }
+    }
+}
+
+#[test]
 fn compact_styles_omit_defaults_but_keep_bold() {
     ensure_pdfium_dir();
     let bytes = fs::read(testdata().join("simple.pdf")).unwrap();

--- a/crates/docray-pptx/tests/golden.rs
+++ b/crates/docray-pptx/tests/golden.rs
@@ -53,6 +53,23 @@ fn element_and_lean_goldens_are_byte_exact_on_every_platform() {
 }
 
 #[test]
+fn markdown_goldens_are_byte_exact() {
+    let golden_dir = root().join("testdata/golden/pptx");
+    for name in ["styled-text", "table"] {
+        let bytes = fs::read(root().join(format!("testdata/pptx/{name}.pptx"))).unwrap();
+        let markdown = PptxExtractor.extract(&bytes, None).unwrap().to_markdown();
+        let path = golden_dir.join(format!("{name}.md"));
+        if std::env::var_os("UPDATE_GOLDEN").is_some() {
+            fs::write(&path, &markdown).unwrap();
+        } else {
+            let expected = fs::read_to_string(&path)
+                .unwrap_or_else(|_| panic!("missing golden {path:?}; run with UPDATE_GOLDEN=1"));
+            assert_eq!(markdown, expected, "Markdown golden mismatch for {name}");
+        }
+    }
+}
+
+#[test]
 fn group_fixture_geometry_matches_hand_math() {
     let bytes = fs::read(root().join("testdata/pptx/groups.pptx")).unwrap();
     let extraction = PptxExtractor.extract(&bytes, None).unwrap();

--- a/crates/docray-server/src/http.rs
+++ b/crates/docray-server/src/http.rs
@@ -123,11 +123,15 @@ fn requested_output(
         None => OutputFormat::Json,
     };
     match (format, granularity) {
-        (OutputFormat::Lean, None) => Ok((Some(Granularity::Element), format)),
-        (OutputFormat::Lean, Some(Granularity::Char)) => Err(OutputQueryError {
-            code: "bad_format",
-            message: "lean format requires element or word granularity".to_string(),
-        }),
+        (OutputFormat::Lean | OutputFormat::Markdown, None) => {
+            Ok((Some(Granularity::Element), format))
+        }
+        (OutputFormat::Lean | OutputFormat::Markdown, Some(Granularity::Char)) => {
+            Err(OutputQueryError {
+                code: "bad_format",
+                message: format!("{format} format requires element or word granularity"),
+            })
+        }
         _ => Ok((granularity, format)),
     }
 }
@@ -163,6 +167,7 @@ fn content_type(format: OutputFormat) -> &'static str {
     match format {
         OutputFormat::Json => "application/json",
         OutputFormat::Lean => "text/plain; charset=utf-8",
+        OutputFormat::Markdown => "text/markdown; charset=utf-8",
     }
 }
 
@@ -435,11 +440,9 @@ async fn job_result(
                     StatusCode::OK,
                     [(
                         "content-type",
-                        if job.format == OutputFormat::Lean.as_str() {
-                            content_type(OutputFormat::Lean)
-                        } else {
-                            content_type(OutputFormat::Json)
-                        },
+                        OutputFormat::from_str(&job.format)
+                            .map(content_type)
+                            .unwrap_or_else(|_| content_type(OutputFormat::Json)),
                     )],
                     bytes,
                 )
@@ -479,6 +482,13 @@ mod tests {
         );
 
         let error = requested_output(Ok(query(Some("char"), Some("lean")))).unwrap_err();
+        assert_eq!(error.code, "bad_format");
+
+        assert_eq!(
+            requested_output(Ok(query(None, Some("md")))).unwrap(),
+            (Some(Granularity::Element), OutputFormat::Markdown)
+        );
+        let error = requested_output(Ok(query(Some("char"), Some("md")))).unwrap_err();
         assert_eq!(error.code, "bad_format");
     }
 

--- a/crates/docray-server/src/jobs.rs
+++ b/crates/docray-server/src/jobs.rs
@@ -328,6 +328,12 @@ mod tests {
         assert_eq!(job.input_path, "in.pdf");
         assert_eq!(job.granularity, Some(Granularity::Word));
         assert_eq!(job.format, OutputFormat::Lean);
+
+        store
+            .create("markdown", "in.pdf", None, OutputFormat::Markdown)
+            .unwrap();
+        let job = store.claim_next().unwrap().unwrap();
+        assert_eq!(job.format, OutputFormat::Markdown);
         std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/docray-server/src/main.rs
+++ b/crates/docray-server/src/main.rs
@@ -115,6 +115,7 @@ async fn process_job(
             let extension = match format {
                 docray_model::OutputFormat::Json => "json",
                 docray_model::OutputFormat::Lean => "lean.txt",
+                docray_model::OutputFormat::Markdown => "md",
             };
             let result_path = cfg
                 .data_dir

--- a/crates/docray-server/src/worker.rs
+++ b/crates/docray-server/src/worker.rs
@@ -29,7 +29,7 @@ pub async fn run_extraction(
     if let Some(level) = granularity {
         cmd.args(["--granularity", level.as_str()]);
     }
-    if format == OutputFormat::Lean {
+    if format != OutputFormat::Json {
         cmd.args(["--format", format.as_str()]);
     }
     if let Some(dir) = &cfg.pdfium_dir {

--- a/crates/docray-server/tests/jobs_api.rs
+++ b/crates/docray-server/tests/jobs_api.rs
@@ -255,3 +255,42 @@ fn lean_job_roundtrips_stored_format_and_content_type() {
         .unwrap()
         .starts_with("#docray word v1.6 pages=1\n#legend "));
 }
+
+#[test]
+fn markdown_job_roundtrips_stored_format_and_content_type() {
+    let server = TestServer::start();
+    let client = reqwest::blocking::Client::new();
+    let r = upload(&server.base, "/v1/jobs?format=md", fixture("simple.pdf"));
+    assert_eq!(r.status(), 202);
+    let id = r.json::<serde_json::Value>().unwrap()["job_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut status = String::new();
+    for _ in 0..100 {
+        let v: serde_json::Value = client
+            .get(format!("{}/v1/jobs/{id}", server.base))
+            .send()
+            .unwrap()
+            .json()
+            .unwrap();
+        status = v["status"].as_str().unwrap().to_string();
+        if status == "succeeded" || status == "failed" {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert_eq!(status, "succeeded");
+
+    let r = client
+        .get(format!("{}/v1/jobs/{id}/result", server.base))
+        .send()
+        .unwrap();
+    assert_eq!(r.status(), 200);
+    assert_eq!(
+        r.headers().get("content-type").unwrap(),
+        "text/markdown; charset=utf-8"
+    );
+    assert!(r.text().unwrap().contains("# **Bold Title**"));
+}

--- a/crates/docray-server/tests/sync_api.rs
+++ b/crates/docray-server/tests/sync_api.rs
@@ -445,6 +445,23 @@ fn extract_lean_content_type_default_and_char_rejection() {
     assert_eq!(r.status(), 400);
     let v: serde_json::Value = r.json().unwrap();
     assert_eq!(v["error"]["code"], "bad_format");
+
+    let r = upload(&server.base, "/v1/extract?format=md", fixture("simple.pdf"));
+    assert_eq!(r.status(), 200);
+    assert_eq!(
+        r.headers().get("content-type").unwrap(),
+        "text/markdown; charset=utf-8"
+    );
+    assert!(r.text().unwrap().contains("# **Bold Title**"));
+
+    let r = upload(
+        &server.base,
+        "/v1/extract?format=md&granularity=char",
+        fixture("simple.pdf"),
+    );
+    assert_eq!(r.status(), 400);
+    let v: serde_json::Value = r.json().unwrap();
+    assert_eq!(v["error"]["code"], "bad_format");
 }
 
 #[test]

--- a/crates/docray-wasm/src/lib.rs
+++ b/crates/docray-wasm/src/lib.rs
@@ -54,6 +54,50 @@ pub fn extract_lean(
         .map_err(WasmError::into_js)
 }
 
+/// Extracts PDF, PPTX, or DOCX and returns deterministic GFM Markdown.
+/// `granularity` accepts "element", "word", or the empty string (element).
+#[wasm_bindgen]
+pub fn extract_markdown(
+    bytes: &[u8],
+    granularity: &str,
+    max_input_bytes: usize,
+    max_output_bytes: usize,
+) -> Result<String, JsValue> {
+    install_panic_hook();
+    extract_markdown_inner(bytes, granularity, max_input_bytes, max_output_bytes)
+        .map_err(WasmError::into_js)
+}
+
+fn extract_markdown_inner(
+    bytes: &[u8],
+    granularity: &str,
+    max_input_bytes: usize,
+    max_output_bytes: usize,
+) -> Result<String, WasmError> {
+    let cap = output_cap(max_output_bytes);
+    if max_input_bytes != 0 && bytes.len() > max_input_bytes {
+        return Err(WasmError::new(
+            "too_large",
+            format!(
+                "input is {} bytes, limit is {max_input_bytes} bytes",
+                bytes.len()
+            ),
+        ));
+    }
+    let granularity = reading_granularity("md", granularity)?;
+    let extraction = extract_document(bytes, Some(granularity))?;
+    let mut writer = CappedString {
+        buf: String::new(),
+        remaining: cap,
+    };
+    match extraction {
+        DocumentExtraction::Paged(extraction) => extraction.write_markdown(&mut writer),
+        DocumentExtraction::Flow(extraction) => extraction.write_markdown(&mut writer),
+    }
+    .map_err(|_| WasmError::new(OUTPUT_TOO_LARGE, format!("output exceeded {cap} bytes")))?;
+    Ok(writer.buf)
+}
+
 fn extract_lean_inner(
     bytes: &[u8],
     granularity: &str,
@@ -70,16 +114,7 @@ fn extract_lean_inner(
             ),
         ));
     }
-    let granularity = match granularity {
-        "" | "element" => Granularity::Element,
-        "word" => Granularity::Word,
-        other => {
-            return Err(WasmError::new(
-                "bad_format",
-                format!("lean format requires element or word granularity, got {other:?}"),
-            ))
-        }
-    };
+    let granularity = reading_granularity("lean", granularity)?;
     let extraction = extract_document(bytes, Some(granularity))?;
     let projected = match &extraction {
         DocumentExtraction::Paged(extraction) => extraction.with_granularity(granularity),
@@ -109,6 +144,17 @@ fn extract_lean_inner(
             Ok(w.buf)
         }
         GranularExtraction::Char(_) => unreachable!("char is rejected above"),
+    }
+}
+
+fn reading_granularity(format: &str, granularity: &str) -> Result<Granularity, WasmError> {
+    match granularity {
+        "" | "element" => Ok(Granularity::Element),
+        "word" => Ok(Granularity::Word),
+        other => Err(WasmError::new(
+            "bad_format",
+            format!("{format} format requires element or word granularity, got {other:?}"),
+        )),
     }
 }
 
@@ -373,7 +419,7 @@ mod tests {
     }
 
     #[test]
-    fn docx_json_and_lean_extract_without_pdfium() {
+    fn docx_json_lean_and_markdown_extract_without_pdfium() {
         let bytes = include_bytes!("../../../testdata/docx/fields.docx");
         let json = extract_inner(bytes, "", 0, 0).unwrap();
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -384,6 +430,12 @@ mod tests {
         let lean = extract_lean_inner(bytes, "", 0, 0).unwrap();
         assert!(lean.starts_with("#docray element v1.7 sections=1"));
         assert!(lean.contains("Cached heading"));
+        let markdown = extract_markdown_inner(bytes, "", 0, 0).unwrap();
+        assert!(markdown.contains("Cached heading"));
+        let error = extract_markdown_inner(bytes, "char", 0, 0).unwrap_err();
+        assert_eq!(error.code, "bad_format");
+        let error = extract_markdown_inner(bytes, "", 0, 5).unwrap_err();
+        assert_eq!(error.code, OUTPUT_TOO_LARGE);
     }
 
     #[test]

--- a/scripts/wasm-parity.cjs
+++ b/scripts/wasm-parity.cjs
@@ -254,6 +254,22 @@ async function main() {
     results.push({ fixture: file + " (lean)", ok: leanOk, failures: leanOk ? [] : [
       `lean differs at line ${firstDiff}: native=${JSON.stringify(nNorm[firstDiff])} wasm=${JSON.stringify(wNorm[firstDiff])}`,
     ], failure_count: leanOk ? 0 : 1 });
+
+    // Markdown is semantic and coordinate-free, so native and WASM output is
+    // expected to be byte-identical even when their Pdfium glyph boxes drift.
+    const mdNative = spawnSync(nativeCli, ["extract", fixturePath, "--format", "md"], {
+      cwd: root,
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    if (mdNative.status !== 0) {
+      throw new Error(`native markdown failed for ${file}: ${mdNative.stderr.trim()}`);
+    }
+    const mdWasm = docray.extract_markdown(fs.readFileSync(fixturePath), "element", 0, 0);
+    const mdOk = mdNative.stdout === mdWasm;
+    results.push({ fixture: file + " (md)", ok: mdOk, failures: mdOk ? [] : [
+      "markdown differs between native and WASM",
+    ], failure_count: mdOk ? 0 : 1 });
   }
 
   const ok = results.every((result) => result.ok);

--- a/testdata/golden/docx/hyperlinks.md
+++ b/testdata/golden/docx/hyperlinks.md
@@ -1,0 +1,4 @@
+[external](https://example.test/literal?x=1&y=2) [internal](#bookmark)
+
+> [!WARNING]
+> no pagination hints; approx\_page omitted

--- a/testdata/golden/docx/numbering.md
+++ b/testdata/golden/docx/numbering.md
@@ -1,0 +1,15 @@
+1. *one*
+
+  1. letter
+
+    1. roman
+
+1. *restart three*
+
+- picture bullet
+
+> [!WARNING]
+> picture bullet for numId "12" level 0 rendered as a bullet
+
+> [!WARNING]
+> no pagination hints; approx\_page omitted

--- a/testdata/golden/docx/roles.md
+++ b/testdata/golden/docx/roles.md
@@ -1,0 +1,10 @@
+# H1
+
+## H2
+
+# Title
+
+> Quote
+
+> [!WARNING]
+> no pagination hints; approx\_page omitted

--- a/testdata/golden/docx/tables.md
+++ b/testdata/golden/docx/tables.md
@@ -1,0 +1,7 @@
+| merged |  |
+| --- | --- |
+|  |  |
+| outer<br>nested | right |
+
+> [!WARNING]
+> no pagination hints; approx\_page omitted

--- a/testdata/golden/link.md
+++ b/testdata/golden/link.md
@@ -1,0 +1,1 @@
+[click me](https://example.com)

--- a/testdata/golden/pptx/styled-text.md
+++ b/testdata/golden/pptx/styled-text.md
@@ -1,0 +1,2 @@
+[**Hello**](https://example.com/styled-run) [theme](https://example.com/styled-run)<br>
+[*Second paragraph*](https://example.com/styled-run)

--- a/testdata/golden/pptx/table.md
+++ b/testdata/golden/pptx/table.md
@@ -1,0 +1,3 @@
+| Merged |  |
+| --- | --- |
+| Left | Right |

--- a/testdata/golden/simple.md
+++ b/testdata/golden/simple.md
@@ -1,0 +1,3 @@
+Hello World
+
+# **Bold Title**


### PR DESCRIPTION
## What & why

Closes #62.

Adds deterministic GitHub-flavored Markdown as a third output format through `--format md`, `?format=md`, async job results, and the WASM `extract_markdown` export.

- PDF and paged output use document-wide body-font inference, stable H1-H4 size clustering, whole-line bold promotion, inline-fragment-aware column detection, left-to-right column sequencing, paragraph/list rendering, run emphasis, annotation links, and page breaks. PDF table-region cells remain plain reading-order text at the explicit #63 seam.
- DOCX flow renders authored headings, nested ordered/bullet lists, quotes, runs, links, breaks, and GFM tables directly.
- PPTX uses its current paged model, with placeholder roles informing headings and existing first-class tables rendered as GFM tables.
- Warnings remain visible as callouts; hidden-channel context is retained in trailing HTML comments without becoming document prose.
- CLI, HTTP, async storage/content types, WASM parity, and public docs all expose the new format.

## Contract impact

- [x] No change to the schema-1.1 (`char`) output. No existing JSON or lean golden changed.
- [x] Error codes / CLI exit codes are unchanged. `md` follows lean's element default and stable `bad_format` rejection for `char`.
- [x] Golden diffs are explained below and were regenerated on Linux using the repository procedure.

## Gates

- [x] Commits are signed off (`git commit -s`) and GPG-signed.
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build -p docray-cli && cargo test --workspace`
- [x] PDF, PPTX, and DOCX fixture generators run twice with byte-identical hashes and zero tracked `testdata/` diffs
- [x] Linux-canonical PDF golden regeneration is diff-free apart from the new Markdown goldens
- [x] `build-wasm.sh` succeeds for Node and browser targets; native/WASM JSON, lean, and Markdown parity passes across all 14 matrix fixtures
- [x] `build-try.sh` and `mdbook build book`
- [x] Docker image build plus health, frozen JSON, Markdown body, and `text/markdown` content-type smoke tests

## Tests

- Exact model tests pin two-column sequencing, document-wide heading inference, bold/italic/link rendering, bullet and letter-list normalization, hostile Markdown/HTML escaping, PPTX title roles, and structured flow Markdown.
- CLI tests pin PDF, PPTX, and DOCX `--format md`, default granularity, and `char` rejection.
- Sync and async server tests pin Markdown bytes, persisted format, result extension, and content type.
- WASM tests pin DOCX Markdown without PDFium, `char` rejection, and streaming output-cap errors.
- The parity matrix compares Markdown byte-for-byte between native and WASM for every existing matrix fixture.

## Golden changes

Only new `.md` files were added; existing `.json` and `.lean.txt` files are byte-identical.

- `simple.md`: body paragraph plus the inferred bold H1.
- `link.md`: annotation-associated Markdown link.
- `pptx/styled-text.md`: bold/italic runs, hard break, and external link target.
- `pptx/table.md`: GFM rows with the merged-cell continuation left empty.
- `docx/roles.md`: H1/H2/title/quote mapping and warning callout.
- `docx/numbering.md`: ordered nesting, restart, bullet, emphasis, and warnings.
- `docx/tables.md`: merged and nested cell text in a rectangular GFM table.
- `docx/hyperlinks.md`: literal external and internal targets plus warning callout.
