### PR TITLE
chore: bump version to 0.5.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "docray-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "docray-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "docray-model",
  "serde",
@@ -583,7 +583,7 @@ dependencies = [
 
 [[package]]
 name = "docray-docx"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "docray-model"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "docray-ooxml"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "docray-core",
  "quick-xml",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pdf"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pptx"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "docray-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "docray-core",
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "docray-wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "docray-core",
  "docray-docx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "0.4.0"
+version = "0.5.0"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Version bump `0.4.0 → 0.5.0` to cut the v0.5.0 release.

## Highlights since v0.4.0
- **Markdown output** (#65) + **PDF table detection** (#66 ruled, #68 borderless/merged) + **reading-order/heading polish** (#67)
- **Garbled-text warning** (#70)
- **Opt-in page classification** `--classify` (schema 1.8) (#72) + **calibration** (#74)
- **Page-level glyph grouping** — `element`/`word` → **schema 1.9** (#77)
- **Page selection** `pages=` on CLI / `/v1/extract` / `/v1/jobs` (#78)

Backward-compatible: the frozen `char`/1.1 contract is unchanged; new schemas (1.8, 1.9) are opt-in / granularity-scoped.

Only `Cargo.toml` + `Cargo.lock` change here. After merge, tag `v0.5.0` to trigger the release build.
