### PR TITLE
feat(server): add OpenTelemetry metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +118,17 @@ dependencies = [
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -320,7 +337,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -674,6 +691,9 @@ dependencies = [
  "futures",
  "libc",
  "num_cpus",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest",
  "rusqlite",
  "serde",
@@ -913,6 +933,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -920,8 +952,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -1068,6 +1100,19 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1268,6 +1313,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1481,7 +1535,7 @@ dependencies = [
  "log",
  "md-5",
  "nom",
- "rand",
+ "rand 0.10.2",
  "rangemap",
  "rayon",
  "sha2",
@@ -1648,6 +1702,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,7 +1807,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "image",
- "itertools",
+ "itertools 0.15.0",
  "js-sys",
  "libloading",
  "log",
@@ -1701,6 +1825,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1751,6 +1895,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +1940,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1834,7 +2010,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -1872,9 +2048,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -1884,7 +2076,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1899,7 +2110,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2072,6 +2283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2573,6 +2785,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2586,6 +2809,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,9 +2843,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2639,7 +2892,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2808,6 +3073,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,6 +3161,15 @@ name = "webpki-root-certs"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3057,6 +3340,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"

--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ an invisible OCR text layer has text elements and is therefore
 Telemetry is opt-in and vendor-neutral. Enable structured JSON events, OTLP
 metrics, or both:
 
+See [`TELEMETRY.md`](TELEMETRY.md) for the full metric catalog, dimensions,
+privacy contract, dashboard guidance, known coverage gaps, and verification
+steps.
+
 ```bash
 # Single-line JSON events on stdout; suitable for any log collector.
 DOCRAY_TELEMETRY_LOGS=json docray-server

--- a/README.md
+++ b/README.md
@@ -241,6 +241,49 @@ an invisible OCR text layer has text elements and is therefore
 | `DOCRAY_MEM_LIMIT_BYTES`   | `2147483648` (2 GiB)                    | Per-worker memory rlimit (Linux only) |
 | `DOCRAY_WORKERS`           | number of CPU cores (min 1)             | Size of the async job worker pool; also bounds concurrent `/v1/extract` extractions. The sync path and the job pool share this knob but keep independent concurrency counts |
 | `DOCRAY_RESULT_TTL_SECS`   | `86400` (24 h)                          | Age at which succeeded/failed jobs and their results are swept |
+| `DOCRAY_TELEMETRY_LOGS`    | `off`                                    | Set to `json` to emit one bounded structured event for each completed extraction |
+| `OTEL_METRICS_EXPORTER`    | `none`                                   | Set to `otlp` to export service metrics over OTLP/HTTP protobuf |
+
+### Telemetry
+
+Telemetry is opt-in and vendor-neutral. Enable structured JSON events, OTLP
+metrics, or both:
+
+```bash
+# Single-line JSON events on stdout; suitable for any log collector.
+DOCRAY_TELEMETRY_LOGS=json docray-server
+
+# OpenTelemetry metrics sent to an OTLP-compatible collector.
+OTEL_METRICS_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318 \
+OTEL_SERVICE_NAME=docray-server \
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=production \
+docray-server
+```
+
+The OTLP exporter uses HTTP/protobuf and honors the standard
+`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`,
+`OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_METRICS_HEADERS`,
+`OTEL_EXPORTER_OTLP_TIMEOUT`, `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`,
+`OTEL_METRIC_EXPORT_INTERVAL`, `OTEL_SERVICE_NAME`, and
+`OTEL_RESOURCE_ATTRIBUTES` variables. This works with an OpenTelemetry
+Collector and OTLP-capable systems such as Prometheus, Grafana, Datadog,
+Honeycomb, and New Relic without vendor SDKs in docray.
+
+The service exports:
+
+- completed requests, errors, and timeouts,
+- end-to-end, queue, and worker duration histograms,
+- active extraction count,
+- input and output size histograms,
+- for LEAN responses, page, warning, textless-page, and element-record counts.
+
+Metric attributes are deliberately bounded to route, format, granularity,
+classification mode, outcome, stable error type, record type, and output
+schema version. Structured events contain the same operational fields plus
+HTTP status and the observed in-flight count. Neither path emits filenames,
+job IDs, source hashes, document text, tenant identifiers, or extracted
+content.
 
 ## Known limitations (v1)
 
@@ -261,6 +304,11 @@ an invisible OCR text layer has text elements and is therefore
   result files live on the task's local disk, so job IDs are only meaningful
   to the instance that created them and do not survive a task replacement.
   See the Deploy section for why v1 is single-task only.
+- **The route-level body limit runs before extraction telemetry.** A request
+  rejected by Axum because its entire HTTP body exceeds the configured route
+  ceiling does not reach the extraction handler and therefore is not counted
+  by the application metrics. Preserve proxy/load-balancer 413 metrics for
+  complete ingress accounting.
 
 ## Testing
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,204 @@
+# Docray telemetry
+
+`docray-server` exposes vendor-neutral operational telemetry for both synchronous
+extractions (`POST /v1/extract`) and asynchronous jobs. Telemetry is disabled by
+default. Operators can enable OpenTelemetry metrics, one-line structured JSON
+events, or both without changing extraction responses.
+
+## Choose an output
+
+| Need | Configuration | Notes |
+|---|---|---|
+| Metrics through an OpenTelemetry Collector | `OTEL_METRICS_EXPORTER=otlp` | OTLP over HTTP/protobuf; recommended for production |
+| One event per completed extraction in the existing log pipeline | `DOCRAY_TELEMETRY_LOGS=json` | JSON is written to stdout |
+| Both | Set both variables | Useful when metrics drive dashboards and logs support individual-event investigation |
+| Neither | Defaults (`none` and `off`) | No telemetry exporter and no telemetry network traffic |
+
+An invalid, explicitly configured telemetry mode fails server startup instead
+of silently disabling the requested output.
+
+## OpenTelemetry setup
+
+Point Docray at an OTLP-capable collector rather than installing a
+vendor-specific SDK in the service:
+
+```bash
+OTEL_METRICS_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318 \
+OTEL_SERVICE_NAME=docray-server \
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=production \
+docray-server
+```
+
+The exporter uses OTLP/HTTP protobuf and honors these standard variables:
+
+| Variable | Purpose |
+|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Base OTLP endpoint; the metrics path is derived by the exporter |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Metrics-specific endpoint; takes precedence over the base endpoint |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Headers shared by OTLP exporters, such as collector authentication |
+| `OTEL_EXPORTER_OTLP_METRICS_HEADERS` | Metrics-specific headers |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | Shared export timeout |
+| `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` | Metrics-specific export timeout |
+| `OTEL_METRIC_EXPORT_INTERVAL` | Periodic metric export interval |
+| `OTEL_SERVICE_NAME` | Service resource name; defaults to `docray-server` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Deployment-level dimensions, such as environment, region, or cluster |
+
+The resource also includes `service.version`, populated from the Docray server
+package version. An OpenTelemetry Collector can route the same metrics to one
+or several systems, such as Prometheus/Grafana, CloudWatch, Datadog, Honeycomb,
+or New Relic, without adding those vendors to Docray.
+
+## Metric catalog
+
+All duration metric values are seconds. Byte histograms use the OpenTelemetry
+unit `By`.
+
+| Metric | Type | Unit | Recorded when |
+|---|---|---|---|
+| `docray.extraction.requests` | Counter | `{request}` | An extraction attempt completes, including validation errors handled by the sync endpoint |
+| `docray.extraction.errors` | Counter | `{error}` | An attempt has any non-success outcome, including timeouts and crashes |
+| `docray.extraction.timeouts` | Counter | `{timeout}` | The service terminates an extraction at `DOCRAY_TIMEOUT_SECS` |
+| `docray.extraction.request.duration` | Histogram | `s` | End-to-end sync handling, or claimed-job processing, completes |
+| `docray.extraction.queue.duration` | Histogram | `s` | A sync request acquires an extraction slot |
+| `docray.extraction.worker.duration` | Histogram | `s` | The child extraction process completes or is terminated |
+| `docray.extraction.active` | Up-down counter | `{request}` | A worker extraction starts or stops |
+| `docray.extraction.input.size` | Histogram | `By` | An input upload or queued job file has a measurable size |
+| `docray.extraction.output.size` | Histogram | `By` | An extraction succeeds |
+| `docray.extraction.pages` | Counter | `{page}` | A successful LEAN response can be summarized |
+| `docray.extraction.records` | Counter | `{record}` | A successful LEAN response emits counted records; split by `docray.record.type` |
+| `docray.extraction.warnings` | Counter | `{warning}` | A successful LEAN response contains warnings |
+| `docray.extraction.textless_pages` | Counter | `{page}` | A successful LEAN response contains a page without readable text payloads |
+
+`request.duration` has slightly different boundaries by route. For `sync`, it
+starts when the HTTP handler begins and includes request validation, upload
+handling, queueing, extraction, and response construction. For `job`, it starts
+after a queued job has been claimed and therefore excludes time spent waiting in
+the persistent job queue. `queue.duration` is currently sync-only.
+
+Content-quality counters are currently LEAN-only. JSON and Markdown outputs are
+not reparsed for telemetry because doing so would require another allocation
+proportional to the response size; their request, outcome, duration, and byte-size
+metrics are still emitted.
+
+## Metric attributes
+
+The following bounded attributes can be used safely for aggregation:
+
+| Attribute | Example values | Applied to |
+|---|---|---|
+| `docray.route` | `sync`, `job` | All metrics |
+| `docray.format` | `lean`, `json`, `markdown`, `unknown` | Completed extraction metrics |
+| `docray.granularity` | `element`, `word`, `char`, `default`, `unknown` | Completed extraction metrics |
+| `docray.classify` | `true`, `false` | Completed extraction metrics |
+| `docray.outcome` | `success`, `error`, `timeout`, `crash` | Completed extraction metrics |
+| `error.type` | Stable service error code | Failed extraction metrics |
+| `http.response.status_code` | HTTP status integer | Sync requests that reach the handler |
+| `docray.schema.version` | LEAN schema version | Successfully summarized LEAN output |
+| `docray.record.type` | `text`, `image`, `path`, `chart`, `table`, `table_cell`, `annotation`, `word` | `docray.extraction.records` only |
+
+Use OpenTelemetry resource attributes—not metric attributes—for deployment
+identity such as environment, region, cluster, or task family. This keeps metric
+cardinality predictable while still allowing the collector or backend to split
+production from demo and development.
+
+## Structured JSON event
+
+Set `DOCRAY_TELEMETRY_LOGS=json` to write one
+`docray.extraction.completed` object to stdout for every recorded extraction.
+The event schema is versioned independently from the Docray output schema:
+
+```json
+{
+  "event": "docray.extraction.completed",
+  "event_schema_version": 1,
+  "timestamp_unix_ms": 1788911397953,
+  "service_name": "docray-server",
+  "service_version": "0.5.0",
+  "route": "sync",
+  "format": "lean",
+  "granularity": "element",
+  "classify": false,
+  "outcome": "success",
+  "status_code": 200,
+  "request_duration_ms": 368.66,
+  "queue_duration_ms": 0.002,
+  "extraction_duration_ms": 368.30,
+  "input_bytes": 725,
+  "output_bytes": 278,
+  "in_flight": 1,
+  "page_count": 1,
+  "text_record_count": 2,
+  "textless_page_count": 0,
+  "warning_count": 0,
+  "schema_version": "1.9"
+}
+```
+
+Fields that are not available for a particular route, outcome, or output format
+are omitted. LEAN events can additionally include counts for image, path, chart,
+table, table-cell, annotation, and word records. Failed events include
+`error_code` when a stable code is available.
+
+## Privacy and cardinality contract
+
+Telemetry is intentionally operational and content-free. Docray does not emit:
+
+- filenames or filesystem paths,
+- job IDs or source hashes,
+- document text or extracted content,
+- tenant, user, or customer identifiers,
+- raw worker error messages.
+
+The service emits counts, byte sizes, timings, controlled modes, stable outcome
+codes, and version identifiers. If a deployment needs tenant-level allocation,
+join or enrich metrics outside Docray at a trusted boundary rather than adding
+tenant IDs as high-cardinality metric labels.
+
+## Recommended dashboards and alerts
+
+Start with four views:
+
+1. **Reliability:** request rate, success rate, errors by `error.type`, timeout
+   rate, and crashes by route.
+2. **Latency:** p50/p95/p99 `request.duration`, `queue.duration`, and
+   `worker.duration`, split by route and output settings.
+3. **Capacity:** `active`, queue latency, input size, output size, and timeout
+   rate. Rising queue latency with high active concurrency is the clearest
+   saturation signal.
+4. **Extraction quality:** warnings per page, textless-page ratio, and record mix
+   for LEAN output. These are screening signals, not document correctness scores.
+
+Useful initial alert candidates are a sustained success-rate drop, any sustained
+crash rate, timeout-rate growth, and p95 queue latency above the caller's latency
+budget. Establish normal baselines before choosing production thresholds.
+
+## Known coverage gaps
+
+- Requests rejected by Axum's route-level body-size limit never enter the
+  extraction handler and are absent from application telemetry. Retain 413 counts
+  from the load balancer, reverse proxy, or access logs for complete ingress
+  accounting.
+- Async job queue age is not currently measured. The job route's
+  `request.duration` begins only after the job is claimed.
+- Job persistence failures that happen after successful extraction are logged by
+  the job system but are not represented as extraction errors.
+- Telemetry currently exports metrics and structured events, not distributed
+  traces. Trace context propagation and spans can be added later without changing
+  this metric contract.
+
+## Verification
+
+For a local JSON smoke test:
+
+```bash
+DOCRAY_TELEMETRY_LOGS=json docray-server
+curl -sS -F file=@testdata/simple.pdf \
+  'http://localhost:41619/v1/extract?format=lean' >/dev/null
+```
+
+The server should write exactly one `docray.extraction.completed` JSON line for
+the request. Check that the line has operational fields only and contains no
+document content. For OTLP, point the exporter at a development collector with a
+debug exporter and verify that all expected metric names and resource attributes
+arrive before enabling a production destination.

--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -17,8 +17,55 @@ to keep hostile or pathological documents from taking the service down.
 | `DOCRAY_MEM_LIMIT_BYTES` | `2147483648` (2 GiB) | Per-worker memory rlimit (enforced on Linux) |
 | `DOCRAY_WORKERS` | CPU cores (min 1) | Job worker pool size; also bounds concurrent sync extractions |
 | `DOCRAY_RESULT_TTL_SECS` | `86400` (24 h) | How long finished jobs and results are kept |
+| `DOCRAY_TELEMETRY_LOGS` | `off` | `json` emits a bounded extraction-completed event to stdout |
+| `OTEL_METRICS_EXPORTER` | `none` | `otlp` enables OpenTelemetry metrics over OTLP/HTTP protobuf |
 
-Invalid values fall back to the default rather than failing startup.
+## Telemetry
+
+Structured events and OTLP metrics are independently opt-in. A typical
+collector configuration is:
+
+```bash
+DOCRAY_TELEMETRY_LOGS=json \
+OTEL_METRICS_EXPORTER=otlp \
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318 \
+OTEL_SERVICE_NAME=docray-server \
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=production \
+docray-server
+```
+
+The exporter honors standard OpenTelemetry endpoint, metric-specific
+endpoint, header, timeout, export interval, service-name, and resource
+attribute variables. Metrics cover request outcomes, latency, queueing,
+concurrency, and byte sizes. LEAN responses also report pages, records,
+warnings, and textless pages. JSON and Markdown responses are not reparsed for
+telemetry, avoiding an additional allocation proportional to a potentially
+large response.
+
+| Metric | Instrument | Unit |
+|---|---|---|
+| `docray.extraction.requests` | Counter | `{request}` |
+| `docray.extraction.errors` | Counter | `{error}` |
+| `docray.extraction.timeouts` | Counter | `{timeout}` |
+| `docray.extraction.request.duration` | Histogram | `s` |
+| `docray.extraction.queue.duration` | Histogram | `s` |
+| `docray.extraction.worker.duration` | Histogram | `s` |
+| `docray.extraction.active` | Up-down counter | `{request}` |
+| `docray.extraction.input.size` | Histogram | `By` |
+| `docray.extraction.output.size` | Histogram | `By` |
+| `docray.extraction.pages` | Counter | `{page}` |
+| `docray.extraction.records` | Counter | `{record}` |
+| `docray.extraction.warnings` | Counter | `{warning}` |
+| `docray.extraction.textless_pages` | Counter | `{page}` |
+
+Only bounded operational attributes are emitted. Filenames, job IDs, source
+hashes, document text, tenant identifiers, and extracted content are never
+telemetry fields. Requests rejected by the route's body-limit layer before
+the extraction handler must be counted at the proxy or load balancer.
+
+Invalid numeric limit values fall back to their defaults. Unknown telemetry
+modes fail startup so an explicitly requested exporter is never silently
+disabled.
 
 ## Sizing guidance
 

--- a/book/src/deployment.md
+++ b/book/src/deployment.md
@@ -33,8 +33,27 @@ health check, and CloudWatch logging. Before registering it:
   One instance is the supported topology; horizontal scaling would require an
   external job store.
 - On restart, jobs that were mid-flight are automatically re-queued.
-- The server needs **no outbound network** — only the playground's browser
-  assets (pdf.js, fonts) load from CDNs, client-side.
+- With telemetry disabled (the default), the server needs **no outbound
+  network** — only the playground's browser assets (pdf.js, fonts) load from
+  CDNs, client-side. Enabling the OTLP exporter requires outbound access to
+  the configured collector.
 - Responses are not compressed at the HTTP layer yet; if you front docray
   with a reverse proxy, enabling gzip/brotli there shrinks `char`-level
   responses dramatically.
+
+## OpenTelemetry
+
+For production, send metrics to an OpenTelemetry Collector rather than
+configuring a vendor SDK in the docray container:
+
+```bash
+OTEL_METRICS_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+OTEL_SERVICE_NAME=docray-server
+OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=production
+```
+
+The collector can fan metrics out to CloudWatch, Prometheus, Grafana,
+Datadog, Honeycomb, New Relic, or multiple destinations. Set
+`DOCRAY_TELEMETRY_LOGS=json` when the deployment also wants per-request
+structured events in its existing log pipeline.

--- a/crates/docray-server/Cargo.toml
+++ b/crates/docray-server/Cargo.toml
@@ -17,6 +17,9 @@ uuid = { version = "1", features = ["v4"] }
 tempfile = "3"
 libc = "0.2"
 num_cpus = "1"
+opentelemetry = { version = "0.32", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.32", default-features = false, features = ["metrics"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["metrics", "http-proto", "reqwest-blocking-client", "tls-webpki-roots"] }
 
 [dev-dependencies]
 reqwest = { version = "0.13", features = ["multipart", "json", "blocking"] }

--- a/crates/docray-server/src/http.rs
+++ b/crates/docray-server/src/http.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::jobs::JobStore;
+use crate::telemetry::{ExtractionMetric, Telemetry};
 use crate::worker::{run_extraction, WorkerOutcome};
 use axum::extract::multipart::MultipartRejection;
 use axum::extract::rejection::QueryRejection;
@@ -14,6 +15,7 @@ use serde::Deserialize;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::Semaphore;
 
 #[derive(Clone)]
@@ -25,15 +27,17 @@ pub struct AppState {
     /// `cfg.workers` — the sync path and the async job pool share the machine but
     /// keep independent concurrency counts, which is acceptable for v1.
     pub sync_slots: Arc<Semaphore>,
+    pub telemetry: Telemetry,
 }
 
 impl AppState {
-    pub fn new(cfg: Arc<Config>, jobs: Arc<JobStore>) -> AppState {
+    pub fn new(cfg: Arc<Config>, jobs: Arc<JobStore>, telemetry: Telemetry) -> AppState {
         let sync_slots = Arc::new(Semaphore::new(cfg.workers));
         AppState {
             cfg,
             jobs,
             sync_slots,
+            telemetry,
         }
     }
 }
@@ -165,30 +169,43 @@ fn requested_output(
     }
 }
 
-pub async fn read_upload(multipart: &mut Multipart, max_bytes: u64) -> Result<Vec<u8>, Response> {
-    while let Some(field) = multipart
-        .next_field()
-        .await
-        .map_err(|e| error_response(StatusCode::BAD_REQUEST, "bad_multipart", &e.to_string()))?
-    {
+async fn read_upload(
+    multipart: &mut Multipart,
+    max_bytes: u64,
+) -> Result<Vec<u8>, (&'static str, Response)> {
+    while let Some(field) = multipart.next_field().await.map_err(|e| {
+        (
+            "bad_multipart",
+            error_response(StatusCode::BAD_REQUEST, "bad_multipart", &e.to_string()),
+        )
+    })? {
         if field.name() == Some("file") {
             let bytes = field.bytes().await.map_err(|e| {
-                error_response(StatusCode::PAYLOAD_TOO_LARGE, "too_large", &e.to_string())
+                (
+                    "too_large",
+                    error_response(StatusCode::PAYLOAD_TOO_LARGE, "too_large", &e.to_string()),
+                )
             })?;
             if bytes.len() as u64 > max_bytes {
-                return Err(error_response(
-                    StatusCode::PAYLOAD_TOO_LARGE,
+                return Err((
                     "too_large",
-                    "request exceeds sync size cap; use POST /v1/jobs",
+                    error_response(
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "too_large",
+                        "request exceeds sync size cap; use POST /v1/jobs",
+                    ),
                 ));
             }
             return Ok(bytes.to_vec());
         }
     }
-    Err(error_response(
-        StatusCode::BAD_REQUEST,
+    Err((
         "missing_file",
-        "multipart field 'file' required",
+        error_response(
+            StatusCode::BAD_REQUEST,
+            "missing_file",
+            "multipart field 'file' required",
+        ),
     ))
 }
 
@@ -243,10 +260,23 @@ async fn sync_extract(
     query: Result<Query<OutputQuery>, QueryRejection>,
     multipart: Result<Multipart, MultipartRejection>,
 ) -> Response {
+    let started = Instant::now();
+    let mut metric = ExtractionMetric::new("sync");
     let (granularity, format, classify, pages) = match requested_output(query) {
         Ok(value) => value,
-        Err(error) => return error_response(StatusCode::BAD_REQUEST, error.code, &error.message),
+        Err(error) => {
+            metric.fail(error.code);
+            return finish_response(
+                &state.telemetry,
+                started,
+                metric,
+                error_response(StatusCode::BAD_REQUEST, error.code, &error.message),
+            );
+        }
     };
+    metric.format = format.as_str();
+    metric.granularity = granularity.map(|value| value.as_str()).unwrap_or("default");
+    metric.classify = classify;
     // axum rejects a malformed multipart request (e.g. bad/missing boundary)
     // before the handler body runs, with a plaintext body. Taking the extractor
     // as a `Result` lets us re-map that rejection into the always-JSON error
@@ -263,43 +293,72 @@ async fn sync_extract(
     let mut multipart = match multipart {
         Ok(m) => m,
         Err(rej) => {
-            return if rej.status() == StatusCode::PAYLOAD_TOO_LARGE {
-                error_response(StatusCode::PAYLOAD_TOO_LARGE, "too_large", &rej.body_text())
+            let (code, response) = if rej.status() == StatusCode::PAYLOAD_TOO_LARGE {
+                (
+                    "too_large",
+                    error_response(StatusCode::PAYLOAD_TOO_LARGE, "too_large", &rej.body_text()),
+                )
             } else {
-                error_response(StatusCode::BAD_REQUEST, "bad_multipart", &rej.body_text())
+                (
+                    "bad_multipart",
+                    error_response(StatusCode::BAD_REQUEST, "bad_multipart", &rej.body_text()),
+                )
             };
+            metric.fail(code);
+            return finish_response(&state.telemetry, started, metric, response);
         }
     };
     let bytes = match read_upload(&mut multipart, state.cfg.sync_max_bytes).await {
         Ok(b) => b,
-        Err(resp) => return resp,
+        Err((code, resp)) => {
+            metric.fail(code);
+            return finish_response(&state.telemetry, started, metric, resp);
+        }
     };
+    metric.input_bytes = Some(bytes.len() as u64);
     let tmp = match tempfile::NamedTempFile::new() {
         Ok(t) => t,
         Err(e) => {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "io_error",
-                &e.to_string(),
-            )
+            metric.fail("io_error");
+            return finish_response(
+                &state.telemetry,
+                started,
+                metric,
+                error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "io_error",
+                    &e.to_string(),
+                ),
+            );
         }
     };
     if let Err(e) = std::fs::write(tmp.path(), &bytes) {
-        return error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "io_error",
-            &e.to_string(),
+        metric.fail("io_error");
+        return finish_response(
+            &state.telemetry,
+            started,
+            metric,
+            error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "io_error",
+                &e.to_string(),
+            ),
         );
     }
     // Bound concurrent sync extractions. We await the permit (bounded queueing)
     // rather than 503-ing on contention: a brief queue is preferable to shedding
     // load, and the request already has the client waiting synchronously. The
     // semaphore is never closed, so acquire() cannot error.
+    let queued = Instant::now();
     let _permit = state
         .sync_slots
         .acquire()
         .await
         .expect("semaphore not closed");
+    metric.queue_duration = Some(queued.elapsed());
+    let active = state.telemetry.begin_extraction("sync");
+    metric.in_flight = Some(active.current());
+    let extraction_started = Instant::now();
     let outcome = run_extraction(
         &state.cfg,
         tmp.path(),
@@ -310,7 +369,23 @@ async fn sync_extract(
         pages,
     )
     .await;
-    outcome_to_response(outcome, format)
+    metric.extraction_duration = Some(extraction_started.elapsed());
+    metric.observe_outcome(&outcome, format);
+    let response = outcome_to_response(outcome, format);
+    drop(active);
+    finish_response(&state.telemetry, started, metric, response)
+}
+
+fn finish_response(
+    telemetry: &Telemetry,
+    started: Instant,
+    mut metric: ExtractionMetric,
+    response: Response,
+) -> Response {
+    metric.request_duration = started.elapsed();
+    metric.status_code = Some(response.status().as_u16());
+    telemetry.record(&metric);
+    response
 }
 
 /// Stream the multipart `file` field straight to `path`, chunk by chunk, so a

--- a/crates/docray-server/src/http.rs
+++ b/crates/docray-server/src/http.rs
@@ -172,28 +172,36 @@ fn requested_output(
 async fn read_upload(
     multipart: &mut Multipart,
     max_bytes: u64,
-) -> Result<Vec<u8>, (&'static str, Response)> {
+) -> Result<Vec<u8>, (&'static str, Box<Response>)> {
     while let Some(field) = multipart.next_field().await.map_err(|e| {
         (
             "bad_multipart",
-            error_response(StatusCode::BAD_REQUEST, "bad_multipart", &e.to_string()),
+            Box::new(error_response(
+                StatusCode::BAD_REQUEST,
+                "bad_multipart",
+                &e.to_string(),
+            )),
         )
     })? {
         if field.name() == Some("file") {
             let bytes = field.bytes().await.map_err(|e| {
                 (
                     "too_large",
-                    error_response(StatusCode::PAYLOAD_TOO_LARGE, "too_large", &e.to_string()),
+                    Box::new(error_response(
+                        StatusCode::PAYLOAD_TOO_LARGE,
+                        "too_large",
+                        &e.to_string(),
+                    )),
                 )
             })?;
             if bytes.len() as u64 > max_bytes {
                 return Err((
                     "too_large",
-                    error_response(
+                    Box::new(error_response(
                         StatusCode::PAYLOAD_TOO_LARGE,
                         "too_large",
                         "request exceeds sync size cap; use POST /v1/jobs",
-                    ),
+                    )),
                 ));
             }
             return Ok(bytes.to_vec());
@@ -201,11 +209,11 @@ async fn read_upload(
     }
     Err((
         "missing_file",
-        error_response(
+        Box::new(error_response(
             StatusCode::BAD_REQUEST,
             "missing_file",
             "multipart field 'file' required",
-        ),
+        )),
     ))
 }
 
@@ -312,7 +320,7 @@ async fn sync_extract(
         Ok(b) => b,
         Err((code, resp)) => {
             metric.fail(code);
-            return finish_response(&state.telemetry, started, metric, resp);
+            return finish_response(&state.telemetry, started, metric, *resp);
         }
     };
     metric.input_bytes = Some(bytes.len() as u64);
@@ -396,61 +404,63 @@ async fn stream_upload_to_file(
     multipart: &mut Multipart,
     path: &Path,
     max_bytes: u64,
-) -> Result<(), Response> {
+) -> Result<(), Box<Response>> {
     use std::io::Write;
-    while let Some(mut field) = multipart
-        .next_field()
-        .await
-        .map_err(|e| error_response(StatusCode::BAD_REQUEST, "bad_multipart", &e.to_string()))?
-    {
+    while let Some(mut field) = multipart.next_field().await.map_err(|e| {
+        Box::new(error_response(
+            StatusCode::BAD_REQUEST,
+            "bad_multipart",
+            &e.to_string(),
+        ))
+    })? {
         if field.name() != Some("file") {
             continue;
         }
         let mut file = std::fs::File::create(path).map_err(|e| {
-            error_response(
+            Box::new(error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "io_error",
                 &e.to_string(),
-            )
+            ))
         })?;
         let mut written: u64 = 0;
         while let Some(chunk) = field.chunk().await.map_err(|e| {
-            error_response(
+            Box::new(error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "io_error",
                 &e.to_string(),
-            )
+            ))
         })? {
             written += chunk.len() as u64;
             if written > max_bytes {
-                return Err(error_response(
+                return Err(Box::new(error_response(
                     StatusCode::PAYLOAD_TOO_LARGE,
                     "too_large",
                     "request exceeds job size cap",
-                ));
+                )));
             }
             file.write_all(&chunk).map_err(|e| {
-                error_response(
+                Box::new(error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     "io_error",
                     &e.to_string(),
-                )
+                ))
             })?;
         }
         file.flush().map_err(|e| {
-            error_response(
+            Box::new(error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "io_error",
                 &e.to_string(),
-            )
+            ))
         })?;
         return Ok(());
     }
-    Err(error_response(
+    Err(Box::new(error_response(
         StatusCode::BAD_REQUEST,
         "missing_file",
         "multipart field 'file' required",
-    ))
+    )))
 }
 
 async fn create_job(
@@ -494,7 +504,7 @@ async fn create_job(
         stream_upload_to_file(&mut multipart, &input_path, state.cfg.jobs_max_bytes).await
     {
         let _ = std::fs::remove_file(&input_path);
-        return resp;
+        return *resp;
     }
 
     if let Err(e) = state.jobs.create(

--- a/crates/docray-server/src/main.rs
+++ b/crates/docray-server/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod http;
 mod jobs;
+mod telemetry;
 mod worker;
 
 use config::Config;
@@ -10,11 +11,16 @@ use jobs::{ClaimedJob, JobStore};
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::sync::Arc;
+use telemetry::{ExtractionMetric, Telemetry};
 use worker::{run_extraction, WorkerOutcome};
 
 #[tokio::main]
 async fn main() {
     let cfg = Arc::new(Config::from_env());
+    let telemetry = Telemetry::from_env().unwrap_or_else(|error| {
+        eprintln!("cannot initialize telemetry: {error}");
+        std::process::exit(1);
+    });
     std::fs::create_dir_all(cfg.data_dir.join("uploads")).expect("cannot create data dir");
     std::fs::create_dir_all(cfg.data_dir.join("results")).expect("cannot create data dir");
     let store = Arc::new(JobStore::new(&cfg.data_dir.join("jobs.sqlite")));
@@ -23,6 +29,7 @@ async fn main() {
     for _ in 0..cfg.workers {
         let cfg = cfg.clone();
         let store = store.clone();
+        let telemetry = telemetry.clone();
         tokio::spawn(async move {
             // The worker loop must never exit: a claim error backs off (no tight
             // error spin) and a panic in the per-job work is caught so the job is
@@ -57,6 +64,7 @@ async fn main() {
                     format,
                     classify,
                     pages,
+                    &telemetry,
                 ));
                 if work.catch_unwind().await.is_err() {
                     if let Err(e) = store.mark_failed(&id, "crash", "worker task panicked") {
@@ -83,7 +91,7 @@ async fn main() {
         });
     }
 
-    let state = AppState::new(cfg.clone(), store);
+    let state = AppState::new(cfg.clone(), store, telemetry.clone());
     let app = http::router(state);
     let addr = format!("0.0.0.0:{}", cfg.port);
     let listener = match tokio::net::TcpListener::bind(&addr).await {
@@ -99,7 +107,36 @@ async fn main() {
         "playground UI:        http://localhost:{}/playground",
         cfg.port
     );
-    axum::serve(listener, app).await.expect("server error");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .expect("server error");
+    if let Err(error) = telemetry.shutdown() {
+        eprintln!("cannot flush telemetry during shutdown: {error}");
+    }
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("cannot install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("cannot install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
+    }
 }
 
 /// Run one claimed job to completion and record its outcome. Store errors while
@@ -115,7 +152,11 @@ async fn process_job(
     format: docray_model::OutputFormat,
     classify: bool,
     pages: Option<docray_core::PageSelection>,
+    telemetry: &Telemetry,
 ) {
+    let started = std::time::Instant::now();
+    let input_bytes = std::fs::metadata(input_path).map(|meta| meta.len()).ok();
+    let active = telemetry.begin_extraction("job");
     let outcome = run_extraction(
         cfg,
         Path::new(input_path),
@@ -126,6 +167,17 @@ async fn process_job(
         pages,
     )
     .await;
+    let mut metric = ExtractionMetric::new("job");
+    metric.format = format.as_str();
+    metric.granularity = granularity.map(|value| value.as_str()).unwrap_or("default");
+    metric.classify = classify;
+    metric.input_bytes = input_bytes;
+    metric.extraction_duration = Some(started.elapsed());
+    metric.request_duration = started.elapsed();
+    metric.in_flight = Some(active.current());
+    metric.observe_outcome(&outcome, format);
+    telemetry.record(&metric);
+    drop(active);
     let marked = match outcome {
         WorkerOutcome::Success(bytes) => {
             let extension = match format {

--- a/crates/docray-server/src/telemetry.rs
+++ b/crates/docray-server/src/telemetry.rs
@@ -1,0 +1,672 @@
+use crate::worker::WorkerOutcome;
+use docray_model::OutputFormat;
+use opentelemetry::metrics::{Counter, Histogram, MeterProvider as _, UpDownCounter};
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::Resource;
+use serde_json::{json, Map};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const EVENT_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Clone)]
+pub struct Telemetry {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    json_events: bool,
+    service_name: String,
+    provider: Option<SdkMeterProvider>,
+    requests: Counter<u64>,
+    errors: Counter<u64>,
+    timeouts: Counter<u64>,
+    request_duration: Histogram<f64>,
+    queue_duration: Histogram<f64>,
+    extraction_duration: Histogram<f64>,
+    input_size: Histogram<u64>,
+    output_size: Histogram<u64>,
+    pages: Counter<u64>,
+    records: Counter<u64>,
+    warnings: Counter<u64>,
+    textless_pages: Counter<u64>,
+    active: UpDownCounter<i64>,
+    active_count: AtomicU64,
+}
+
+impl Telemetry {
+    pub fn from_env() -> Result<Self, String> {
+        let json_events = parse_json_events(
+            &std::env::var("DOCRAY_TELEMETRY_LOGS").unwrap_or_else(|_| "off".into()),
+        )?;
+        let otlp_enabled = parse_metrics_exporters(
+            &std::env::var("OTEL_METRICS_EXPORTER").unwrap_or_else(|_| "none".into()),
+        )?;
+        let service_name =
+            std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "docray-server".into());
+
+        let provider = if otlp_enabled {
+            let exporter = opentelemetry_otlp::MetricExporter::builder()
+                .with_http()
+                .build()
+                .map_err(|error| error.to_string())?;
+            let resource = Resource::builder()
+                .with_service_name(service_name.clone())
+                .with_attribute(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")))
+                .build();
+            Some(
+                SdkMeterProvider::builder()
+                    .with_resource(resource)
+                    .with_periodic_exporter(exporter)
+                    .build(),
+            )
+        } else {
+            None
+        };
+
+        let meter = match &provider {
+            Some(provider) => provider.meter("docray-server"),
+            None => opentelemetry::global::meter("docray-server"),
+        };
+        let requests = meter
+            .u64_counter("docray.extraction.requests")
+            .with_description("Extraction requests completed")
+            .with_unit("{request}")
+            .build();
+        let errors = meter
+            .u64_counter("docray.extraction.errors")
+            .with_description("Extraction requests completed with an error")
+            .with_unit("{error}")
+            .build();
+        let timeouts = meter
+            .u64_counter("docray.extraction.timeouts")
+            .with_description("Extraction requests terminated by the service timeout")
+            .with_unit("{timeout}")
+            .build();
+        let request_duration = meter
+            .f64_histogram("docray.extraction.request.duration")
+            .with_description("End-to-end extraction request duration")
+            .with_unit("s")
+            .build();
+        let queue_duration = meter
+            .f64_histogram("docray.extraction.queue.duration")
+            .with_description("Time a synchronous extraction waited for a worker slot")
+            .with_unit("s")
+            .build();
+        let extraction_duration = meter
+            .f64_histogram("docray.extraction.worker.duration")
+            .with_description("Time spent running the extraction worker")
+            .with_unit("s")
+            .build();
+        let input_size = meter
+            .u64_histogram("docray.extraction.input.size")
+            .with_description("Uploaded document size")
+            .with_unit("By")
+            .build();
+        let output_size = meter
+            .u64_histogram("docray.extraction.output.size")
+            .with_description("Successful extraction response size")
+            .with_unit("By")
+            .build();
+        let pages = meter
+            .u64_counter("docray.extraction.pages")
+            .with_description("Pages emitted by successful extractions")
+            .with_unit("{page}")
+            .build();
+        let records = meter
+            .u64_counter("docray.extraction.records")
+            .with_description("Element records emitted by successful extractions")
+            .with_unit("{record}")
+            .build();
+        let warnings = meter
+            .u64_counter("docray.extraction.warnings")
+            .with_description("Extraction warnings emitted")
+            .with_unit("{warning}")
+            .build();
+        let textless_pages = meter
+            .u64_counter("docray.extraction.textless_pages")
+            .with_description("LEAN pages emitted without readable text content")
+            .with_unit("{page}")
+            .build();
+        let active = meter
+            .i64_up_down_counter("docray.extraction.active")
+            .with_description("Extractions currently running")
+            .with_unit("{request}")
+            .build();
+
+        Ok(Self {
+            inner: Arc::new(Inner {
+                json_events,
+                service_name,
+                provider,
+                requests,
+                errors,
+                timeouts,
+                request_duration,
+                queue_duration,
+                extraction_duration,
+                input_size,
+                output_size,
+                pages,
+                records,
+                warnings,
+                textless_pages,
+                active,
+                active_count: AtomicU64::new(0),
+            }),
+        })
+    }
+
+    pub fn begin_extraction(&self, route: &'static str) -> ActiveExtraction {
+        let current = self.inner.active_count.fetch_add(1, Ordering::Relaxed) + 1;
+        self.inner
+            .active
+            .add(1, &[KeyValue::new("docray.route", route)]);
+        ActiveExtraction {
+            telemetry: self.clone(),
+            route,
+            current,
+        }
+    }
+
+    pub fn record(&self, metric: &ExtractionMetric) {
+        let attributes = metric.attributes();
+        self.inner.requests.add(1, &attributes);
+        self.inner
+            .request_duration
+            .record(metric.request_duration.as_secs_f64(), &attributes);
+        if metric.outcome != "success" {
+            self.inner.errors.add(1, &attributes);
+        }
+        if metric.outcome == "timeout" {
+            self.inner.timeouts.add(1, &attributes);
+        }
+        if let Some(duration) = metric.queue_duration {
+            self.inner
+                .queue_duration
+                .record(duration.as_secs_f64(), &attributes);
+        }
+        if let Some(duration) = metric.extraction_duration {
+            self.inner
+                .extraction_duration
+                .record(duration.as_secs_f64(), &attributes);
+        }
+        if let Some(bytes) = metric.input_bytes {
+            self.inner.input_size.record(bytes, &attributes);
+        }
+        if let Some(stats) = &metric.output {
+            self.inner
+                .output_size
+                .record(stats.output_bytes, &attributes);
+            if let Some(count) = stats.page_count {
+                self.inner.pages.add(count, &attributes);
+            }
+            for (kind, count) in stats.record_counts() {
+                let mut record_attributes = attributes.clone();
+                record_attributes.push(KeyValue::new("docray.record.type", kind));
+                self.inner.records.add(count, &record_attributes);
+            }
+            if let Some(count) = stats.warning_count {
+                if count > 0 {
+                    self.inner.warnings.add(count, &attributes);
+                }
+            }
+            if let Some(count) = stats.textless_page_count {
+                if count > 0 {
+                    self.inner.textless_pages.add(count, &attributes);
+                }
+            }
+        }
+
+        if self.inner.json_events {
+            println!("{}", metric.to_json_line(&self.inner.service_name));
+        }
+    }
+
+    pub fn shutdown(&self) -> Result<(), String> {
+        match &self.inner.provider {
+            Some(provider) => provider.shutdown().map_err(|error| error.to_string()),
+            None => Ok(()),
+        }
+    }
+}
+
+fn parse_json_events(value: &str) -> Result<bool, String> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "off" | "false" | "0" | "no" | "" => Ok(false),
+        "json" | "true" | "1" | "yes" => Ok(true),
+        other => Err(format!(
+            "DOCRAY_TELEMETRY_LOGS must be 'off' or 'json', got {other:?}"
+        )),
+    }
+}
+
+fn parse_metrics_exporters(value: &str) -> Result<bool, String> {
+    let exporters = value
+        .split(',')
+        .map(str::trim)
+        .filter(|exporter| !exporter.is_empty())
+        .collect::<Vec<_>>();
+    if exporters.is_empty() || (exporters.len() == 1 && exporters[0].eq_ignore_ascii_case("none")) {
+        return Ok(false);
+    }
+    if exporters
+        .iter()
+        .all(|exporter| exporter.eq_ignore_ascii_case("otlp"))
+    {
+        return Ok(true);
+    }
+    Err(format!(
+        "OTEL_METRICS_EXPORTER supports 'none' or 'otlp', got {value:?}"
+    ))
+}
+
+pub struct ActiveExtraction {
+    telemetry: Telemetry,
+    route: &'static str,
+    current: u64,
+}
+
+impl ActiveExtraction {
+    pub fn current(&self) -> u64 {
+        self.current
+    }
+}
+
+impl Drop for ActiveExtraction {
+    fn drop(&mut self) {
+        self.telemetry
+            .inner
+            .active_count
+            .fetch_sub(1, Ordering::Relaxed);
+        self.telemetry
+            .inner
+            .active
+            .add(-1, &[KeyValue::new("docray.route", self.route)]);
+    }
+}
+
+pub struct ExtractionMetric {
+    pub route: &'static str,
+    pub format: &'static str,
+    pub granularity: &'static str,
+    pub classify: bool,
+    pub outcome: &'static str,
+    pub error_code: Option<String>,
+    pub status_code: Option<u16>,
+    pub request_duration: Duration,
+    pub queue_duration: Option<Duration>,
+    pub extraction_duration: Option<Duration>,
+    pub input_bytes: Option<u64>,
+    pub output: Option<OutputStats>,
+    pub in_flight: Option<u64>,
+}
+
+impl ExtractionMetric {
+    pub fn new(route: &'static str) -> Self {
+        Self {
+            route,
+            format: "unknown",
+            granularity: "unknown",
+            classify: false,
+            outcome: "error",
+            error_code: Some("request_incomplete".into()),
+            status_code: None,
+            request_duration: Duration::ZERO,
+            queue_duration: None,
+            extraction_duration: None,
+            input_bytes: None,
+            output: None,
+            in_flight: None,
+        }
+    }
+
+    pub fn fail(&mut self, code: impl Into<String>) {
+        self.outcome = "error";
+        self.error_code = Some(code.into());
+    }
+
+    pub fn observe_outcome(&mut self, outcome: &WorkerOutcome, format: OutputFormat) {
+        match outcome {
+            WorkerOutcome::Success(bytes) => {
+                self.outcome = "success";
+                self.error_code = None;
+                self.output = Some(OutputStats::from_output(format, bytes));
+            }
+            WorkerOutcome::Failed { code, .. } => self.fail(code.clone()),
+            WorkerOutcome::Timeout => {
+                self.outcome = "timeout";
+                self.error_code = Some("timeout".into());
+            }
+            WorkerOutcome::Crashed => {
+                self.outcome = "crash";
+                self.error_code = Some("crash".into());
+            }
+            WorkerOutcome::OutputTooLarge => {
+                self.outcome = "error";
+                self.error_code = Some("output_too_large".into());
+            }
+        }
+    }
+
+    fn attributes(&self) -> Vec<KeyValue> {
+        let mut attributes = vec![
+            KeyValue::new("docray.route", self.route),
+            KeyValue::new("docray.format", self.format),
+            KeyValue::new("docray.granularity", self.granularity),
+            KeyValue::new("docray.classify", self.classify),
+            KeyValue::new("docray.outcome", self.outcome),
+        ];
+        if let Some(code) = &self.error_code {
+            attributes.push(KeyValue::new("error.type", code.clone()));
+        }
+        if let Some(status_code) = self.status_code {
+            attributes.push(KeyValue::new(
+                "http.response.status_code",
+                i64::from(status_code),
+            ));
+        }
+        if let Some(stats) = &self.output {
+            if let Some(version) = &stats.schema_version {
+                attributes.push(KeyValue::new("docray.schema.version", version.clone()));
+            }
+        }
+        attributes
+    }
+
+    fn to_json_line(&self, service_name: &str) -> String {
+        serde_json::to_string(&self.to_json_value(service_name))
+            .unwrap_or_else(|_| "{\"event\":\"docray.telemetry.serialization_error\"}".into())
+    }
+
+    fn to_json_value(&self, service_name: &str) -> serde_json::Value {
+        let mut fields = Map::new();
+        fields.insert("event".into(), json!("docray.extraction.completed"));
+        fields.insert("event_schema_version".into(), json!(EVENT_SCHEMA_VERSION));
+        fields.insert("timestamp_unix_ms".into(), json!(unix_time_ms()));
+        fields.insert("service_name".into(), json!(service_name));
+        fields.insert("service_version".into(), json!(env!("CARGO_PKG_VERSION")));
+        fields.insert("route".into(), json!(self.route));
+        fields.insert("format".into(), json!(self.format));
+        fields.insert("granularity".into(), json!(self.granularity));
+        fields.insert("classify".into(), json!(self.classify));
+        fields.insert("outcome".into(), json!(self.outcome));
+        fields.insert(
+            "request_duration_ms".into(),
+            json!(duration_ms(self.request_duration)),
+        );
+        insert_optional(&mut fields, "error_code", self.error_code.as_ref());
+        insert_optional(&mut fields, "status_code", self.status_code.as_ref());
+        insert_optional(
+            &mut fields,
+            "queue_duration_ms",
+            self.queue_duration.map(duration_ms).as_ref(),
+        );
+        insert_optional(
+            &mut fields,
+            "extraction_duration_ms",
+            self.extraction_duration.map(duration_ms).as_ref(),
+        );
+        insert_optional(&mut fields, "input_bytes", self.input_bytes.as_ref());
+        insert_optional(&mut fields, "in_flight", self.in_flight.as_ref());
+        if let Some(stats) = &self.output {
+            fields.insert("output_bytes".into(), json!(stats.output_bytes));
+            insert_optional(&mut fields, "page_count", stats.page_count.as_ref());
+            insert_optional(
+                &mut fields,
+                "text_record_count",
+                stats.text_record_count.as_ref(),
+            );
+            insert_optional(
+                &mut fields,
+                "image_record_count",
+                stats.image_record_count.as_ref(),
+            );
+            insert_optional(
+                &mut fields,
+                "path_record_count",
+                stats.path_record_count.as_ref(),
+            );
+            insert_optional(
+                &mut fields,
+                "chart_record_count",
+                stats.chart_record_count.as_ref(),
+            );
+            insert_optional(
+                &mut fields,
+                "table_record_count",
+                stats.table_record_count.as_ref(),
+            );
+            insert_optional(
+                &mut fields,
+                "table_cell_record_count",
+                stats.table_cell_record_count.as_ref(),
+            );
+            insert_optional(
+                &mut fields,
+                "annotation_record_count",
+                stats.annotation_record_count.as_ref(),
+            );
+            insert_optional(
+                &mut fields,
+                "word_record_count",
+                stats.word_record_count.as_ref(),
+            );
+            insert_optional(&mut fields, "warning_count", stats.warning_count.as_ref());
+            insert_optional(
+                &mut fields,
+                "textless_page_count",
+                stats.textless_page_count.as_ref(),
+            );
+            insert_optional(&mut fields, "schema_version", stats.schema_version.as_ref());
+        }
+        fields.into()
+    }
+}
+
+fn insert_optional<T: serde::Serialize>(
+    fields: &mut Map<String, serde_json::Value>,
+    key: &str,
+    value: Option<&T>,
+) {
+    if let Some(value) = value {
+        fields.insert(key.into(), json!(value));
+    }
+}
+
+fn unix_time_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
+}
+
+#[derive(Default)]
+pub struct OutputStats {
+    output_bytes: u64,
+    page_count: Option<u64>,
+    text_record_count: Option<u64>,
+    image_record_count: Option<u64>,
+    path_record_count: Option<u64>,
+    chart_record_count: Option<u64>,
+    table_record_count: Option<u64>,
+    table_cell_record_count: Option<u64>,
+    annotation_record_count: Option<u64>,
+    word_record_count: Option<u64>,
+    warning_count: Option<u64>,
+    textless_page_count: Option<u64>,
+    schema_version: Option<String>,
+}
+
+impl OutputStats {
+    fn from_output(format: OutputFormat, bytes: &[u8]) -> Self {
+        let mut stats = Self {
+            output_bytes: bytes.len() as u64,
+            ..Self::default()
+        };
+        match format {
+            OutputFormat::Lean => stats.read_lean(bytes),
+            OutputFormat::Json | OutputFormat::Markdown => {}
+        }
+        stats
+    }
+
+    fn read_lean(&mut self, bytes: &[u8]) {
+        let Ok(text) = std::str::from_utf8(bytes) else {
+            return;
+        };
+        let mut page_count = 0;
+        let mut text_count = 0;
+        let mut image_count = 0;
+        let mut path_count = 0;
+        let mut chart_count = 0;
+        let mut table_count = 0;
+        let mut table_cell_count = 0;
+        let mut annotation_count = 0;
+        let mut word_count = 0;
+        let mut warning_count = 0;
+        let mut current_page_has_text = false;
+        let mut in_page = false;
+        let mut textless_pages = 0;
+
+        for line in text.lines() {
+            if let Some(header) = line.strip_prefix("#docray ") {
+                self.schema_version = header
+                    .split_ascii_whitespace()
+                    .find_map(|part| part.strip_prefix('v'))
+                    .map(str::to_string);
+            } else if line.starts_with("#warning ") {
+                warning_count += 1;
+            } else if line.starts_with("#page ") {
+                if in_page && !current_page_has_text {
+                    textless_pages += 1;
+                }
+                page_count += 1;
+                in_page = true;
+                current_page_has_text = false;
+            } else if line.starts_with("T ") {
+                text_count += 1;
+                current_page_has_text |= lean_record_has_payload(line, 8);
+            } else if line.starts_with("w ") {
+                word_count += 1;
+                current_page_has_text |= lean_record_has_payload(line, 5);
+            } else if line.starts_with("r ") {
+                current_page_has_text |= lean_record_has_payload(line, 4);
+            } else if line.starts_with("I ") {
+                image_count += 1;
+            } else if line.starts_with("P ") {
+                path_count += 1;
+            } else if line.starts_with("CH ") {
+                chart_count += 1;
+            } else if line.starts_with("TB ") {
+                table_count += 1;
+            } else if line.starts_with("c ") {
+                table_cell_count += 1;
+                current_page_has_text |= lean_record_has_payload(line, 12);
+            } else if line.starts_with("A ") {
+                annotation_count += 1;
+            }
+        }
+        if in_page && !current_page_has_text {
+            textless_pages += 1;
+        }
+        if !in_page {
+            self.warning_count = Some(warning_count);
+            return;
+        }
+        self.page_count = Some(page_count);
+        self.text_record_count = Some(text_count);
+        self.image_record_count = Some(image_count);
+        self.path_record_count = Some(path_count);
+        self.chart_record_count = Some(chart_count);
+        self.table_record_count = Some(table_count);
+        self.table_cell_record_count = Some(table_cell_count);
+        self.annotation_record_count = Some(annotation_count);
+        self.word_record_count = Some(word_count);
+        self.warning_count = Some(warning_count);
+        self.textless_page_count = Some(textless_pages);
+    }
+
+    fn record_counts(&self) -> impl Iterator<Item = (&'static str, u64)> {
+        [
+            ("text", self.text_record_count),
+            ("image", self.image_record_count),
+            ("path", self.path_record_count),
+            ("chart", self.chart_record_count),
+            ("table", self.table_record_count),
+            ("table_cell", self.table_cell_record_count),
+            ("annotation", self.annotation_record_count),
+            ("word", self.word_record_count),
+        ]
+        .into_iter()
+        .filter_map(|(kind, count)| count.filter(|count| *count > 0).map(|count| (kind, count)))
+    }
+}
+
+fn lean_record_has_payload(line: &str, fixed_fields: usize) -> bool {
+    line.split_ascii_whitespace().count() > fixed_fields
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lean_stats_are_bounded_counts_only() {
+        let lean = b"#docray element v1.9 pages=2 warnings=1\n#warning recovered page\n#page 1 612x792\nT 1 2 3 4 Helvetica 12 - hello\nI 0 0 10 10\nP 0 0 1 1\n#page 2 612x792\nI 0 0 10 10\n";
+        let stats = OutputStats::from_output(OutputFormat::Lean, lean);
+        assert_eq!(stats.page_count, Some(2));
+        assert_eq!(stats.text_record_count, Some(1));
+        assert_eq!(stats.image_record_count, Some(2));
+        assert_eq!(stats.path_record_count, Some(1));
+        assert_eq!(stats.warning_count, Some(1));
+        assert_eq!(stats.textless_page_count, Some(1));
+        assert_eq!(stats.schema_version.as_deref(), Some("1.9"));
+    }
+
+    #[test]
+    fn non_lean_output_is_not_reparsed_for_metrics() {
+        let bytes = include_bytes!("../../../testdata/golden/simple.element.json");
+        let stats = OutputStats::from_output(OutputFormat::Json, bytes);
+        assert_eq!(stats.output_bytes, bytes.len() as u64);
+        assert_eq!(stats.page_count, None);
+        assert_eq!(stats.text_record_count, None);
+        assert_eq!(stats.schema_version, None);
+    }
+
+    #[test]
+    fn structured_event_contains_no_document_content() {
+        let mut metric = ExtractionMetric::new("sync");
+        metric.format = "lean";
+        metric.granularity = "element";
+        metric.outcome = "success";
+        metric.error_code = None;
+        metric.input_bytes = Some(123);
+        metric.request_duration = Duration::from_millis(50);
+        metric.output = Some(OutputStats::from_output(
+            OutputFormat::Lean,
+            b"#docray element v1.9 pages=1\n#page 1 10x10\nT 0 0 1 1 F 1 - secret text\n",
+        ));
+        let encoded = metric.to_json_line("docray-test");
+        assert!(encoded.contains("\"text_record_count\":1"));
+        assert!(encoded.contains("\"service_name\":\"docray-test\""));
+        assert!(!encoded.contains("secret text"));
+    }
+
+    #[test]
+    fn telemetry_modes_validate_configuration() {
+        assert!(!parse_json_events("off").unwrap());
+        assert!(parse_json_events("JSON").unwrap());
+        assert!(parse_json_events("xml").is_err());
+        assert!(!parse_metrics_exporters("none").unwrap());
+        assert!(parse_metrics_exporters("otlp").unwrap());
+        assert!(parse_metrics_exporters("OTLP").unwrap());
+        assert!(parse_metrics_exporters("prometheus").is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds opt-in OpenTelemetry metrics over OTLP/HTTP and structured JSON completion events.
- Covers sync and async extraction reliability, latency, capacity, byte-size, and LEAN output-shape signals.
- Defaults off and never emits document content or identifiers.

See TELEMETRY.md for configuration, metric definitions, privacy guarantees, and operational guidance.

## Validation

- cargo fmt, clippy, and workspace tests
- Rust 1.88 server build/tests
- Live structured-event smoke test; no golden changes