### PR TITLE
release: bump to v0.5.2 and verify tag version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,19 @@ env:
   PDFIUM_VERSION: chromium/7934
 
 jobs:
+  release-version:
+    name: release version gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Test release version validation
+        run: python3 -m unittest discover -s scripts -p 'test_verify_release_version.py'
+      - name: Validate the current workspace version
+        run: |
+          VERSION=$(python3 -c 'import tomllib; print(tomllib.load(open("Cargo.toml", "rb"))["workspace"]["package"]["version"])')
+          python3 scripts/verify_release_version.py "v${VERSION}"
+
   test:
     name: test · clippy · fmt · determinism
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,20 @@ env:
   PDFIUM_VERSION: chromium/7934
 
 jobs:
+  verify-version:
+    name: verify release version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Require tag to match Cargo workspace version
+        run: python3 scripts/verify_release_version.py "$GITHUB_REF_NAME"
+
   binaries:
     name: binaries · ${{ matrix.target }}
+    needs: verify-version
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -76,6 +88,7 @@ jobs:
 
   image:
     name: ghcr image · ${{ matrix.arch }}
+    needs: verify-version
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,7 +605,7 @@ dependencies = [
 
 [[package]]
 name = "docray-cli"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "docray-core"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "docray-model",
  "serde",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "docray-docx"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "docray-model"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "docray-ooxml"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "docray-core",
  "quick-xml",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pdf"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "docray-pptx"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "docray-core",
  "docray-model",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "docray-server"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "axum",
  "docray-core",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "docray-wasm"
-version = "0.5.0"
+version = "0.5.2"
 dependencies = [
  "docray-core",
  "docray-docx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["crates/*"]
 [workspace.package]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-version = "0.5.0"
+version = "0.5.2"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/scripts/test_verify_release_version.py
+++ b/scripts/test_verify_release_version.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from verify_release_version import verify_release_version
+
+
+class VerifyReleaseVersionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.manifest = Path(self.temp_dir.name) / "Cargo.toml"
+        self.manifest.write_text(
+            '[workspace]\n[workspace.package]\nversion = "0.5.2"\n'
+        )
+
+    def test_accepts_matching_release_tag(self) -> None:
+        self.assertEqual(
+            verify_release_version("v0.5.2", self.manifest),
+            "0.5.2",
+        )
+
+    def test_rejects_tag_that_does_not_match_workspace(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "release tag 'v0.5.1' does not match workspace package version '0.5.2'",
+        ):
+            verify_release_version("v0.5.1", self.manifest)
+
+    def test_rejects_malformed_release_tag(self) -> None:
+        for tag in ("0.5.2", "v0.5", "v0.5.2-rc.1", "release-v0.5.2"):
+            with self.subTest(tag=tag), self.assertRaisesRegex(
+                ValueError, "release tag must be exactly vX.Y.Z"
+            ):
+                verify_release_version(tag, self.manifest)
+
+    def test_rejects_manifest_without_workspace_version(self) -> None:
+        self.manifest.write_text('[workspace]\nmembers = ["crates/*"]\n')
+
+        with self.assertRaises(KeyError):
+            verify_release_version("v0.5.2", self.manifest)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/verify_release_version.py
+++ b/scripts/verify_release_version.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Fail when a release tag does not match the Rust workspace version."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+RELEASE_TAG = re.compile(r"^v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$")
+
+
+def verify_release_version(tag: str, manifest_path: Path) -> str:
+    match = RELEASE_TAG.fullmatch(tag)
+    if match is None:
+        raise ValueError(f"release tag must be exactly vX.Y.Z; got {tag!r}")
+
+    with manifest_path.open("rb") as manifest:
+        workspace_version = tomllib.load(manifest)["workspace"]["package"]["version"]
+
+    tag_version = match.group("version")
+    if tag_version != workspace_version:
+        raise ValueError(
+            f"release tag {tag!r} does not match workspace package version "
+            f"{workspace_version!r}"
+        )
+    return workspace_version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="Git release tag, exactly vX.Y.Z")
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("Cargo.toml"),
+        help="workspace Cargo.toml (default: ./Cargo.toml)",
+    )
+    args = parser.parse_args()
+
+    try:
+        version = verify_release_version(args.tag, args.manifest)
+    except (KeyError, OSError, tomllib.TOMLDecodeError, ValueError) as error:
+        print(f"release version check failed: {error}", file=sys.stderr)
+        return 1
+
+    print(f"release tag {args.tag} matches workspace package version {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- bump the Rust workspace and lockfile package versions from 0.5.0 to 0.5.2
- add a release prerequisite that requires `GITHUB_REF_NAME` to exactly match `[workspace.package].version`
- gate both binary archives and GHCR image builds on that prerequisite, preventing mismatched artifacts from being published
- exercise matching, mismatched, malformed, and missing-version cases in pull-request CI

After this PR merges and CI is green, create the `v0.5.2` tag from the merge commit. Do not tag the PR branch.

## Validation

- `python3 -m unittest discover -s scripts -p "test_verify_release_version.py"`
- `python3 scripts/verify_release_version.py v0.5.2`
- confirmed `v0.5.1` is rejected against the updated workspace
- `cargo fmt --check`
- `cargo check --workspace`
- `actionlint .github/workflows/*.yml`
- `git diff --check`